### PR TITLE
POL-226 Allow to only retrieve the latest alert per trigger.

### DIFF
--- a/api/src/main/java/org/hawkular/alerts/api/services/AlertsCriteria.java
+++ b/api/src/main/java/org/hawkular/alerts/api/services/AlertsCriteria.java
@@ -34,6 +34,7 @@ public class AlertsCriteria {
     Collection<String> triggerIds = null;
     String tagQuery = null;
     boolean thin = false;
+    boolean latestOnly = false;
 
     public AlertsCriteria() {
         super();
@@ -42,7 +43,7 @@ public class AlertsCriteria {
     public AlertsCriteria(Long startTime, Long endTime, String alertIds, String triggerIds,
                           String statuses, String severities, String tagQuery, Long startResolvedTime,
                           Long endResolvedTime, Long startAckTime, Long endAckTime, Long startStatusTime,
-                          Long endStatusTime, Boolean thin) {
+                          Long endStatusTime, Boolean thin, Boolean latestOnly) {
         setStartTime(startTime);
         setEndTime(endTime);
         if (!isEmpty(alertIds)) {
@@ -74,6 +75,9 @@ public class AlertsCriteria {
         setEndStatusTime(endStatusTime);
         if (null != thin) {
             setThin(thin.booleanValue());
+        }
+        if (null != latestOnly) {
+            setLatestOnly(latestOnly);
         }
     }
 
@@ -276,6 +280,14 @@ public class AlertsCriteria {
 
     public void setThin(boolean thin) {
         this.thin = thin;
+    }
+
+    public boolean isLatestOnly() {
+        return latestOnly;
+    }
+
+    public void setLatestOnly(boolean latestOnly) {
+        this.latestOnly = latestOnly;
     }
 
     public boolean hasAlertIdCriteria() {

--- a/external/src/main/java/com/redhat/cloud/policies/engine/handlers/AlertsHandler.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/handlers/AlertsHandler.java
@@ -58,6 +58,7 @@ public class AlertsHandler {
     private static final String PARAM_TEXT = "text";
     private static final String PARAM_TAG_NAMES = "tagNames";
     private static final String PARAM_THIN = "thin";
+    private static final String PARAM_LATEST_ONLY = "latestOnly";
     private static final String PARAM_RESOLVED_BY = "resolvedBy";
     private static final String PARAM_RESOLVED_NOTES = "resolvedNotes";
 
@@ -80,7 +81,8 @@ public class AlertsHandler {
                 PARAM_END_ACK_TIME,
                 PARAM_START_STATUS_TIME,
                 PARAM_END_STATUS_TIME,
-                PARAM_THIN);
+                PARAM_THIN,
+                PARAM_LATEST_ONLY);
         queryParamValidationMap.put(FIND_ALERTS, new HashSet<>(ALERTS_CRITERIA));
         queryParamValidationMap.get(FIND_ALERTS).addAll(ResponseUtil.PARAMS_PAGING);
         queryParamValidationMap.put(WATCH_ALERTS, new HashSet<>(ALERTS_CRITERIA));
@@ -138,7 +140,7 @@ public class AlertsHandler {
             @DocParameter(name = "startTime", type = Long.class,
                     description = "Filter out alerts created before this time.",
                     allowableValues = "Timestamp in millisecond since epoch."),
-            @DocParameter(name = "entTime", type = Long.class,
+            @DocParameter(name = "endTime", type = Long.class,
                     description = "Filter out alerts created after this time.",
                     allowableValues = "Timestamp in millisecond since epoch."),
             @DocParameter(name = "alertIds",
@@ -179,7 +181,9 @@ public class AlertsHandler {
                     description = "Filter out alerts with some lifecycle after this time.",
                     allowableValues = "Timestamp in millisecond since epoch."),
             @DocParameter(name = "thin", type = Boolean.class,
-                    description = "Return only thin alerts, do not include: evalSets, resolvedEvalSets.")
+                    description = "Return only thin alerts, do not include: evalSets, resolvedEvalSets."),
+            @DocParameter(name = "latestOnly", type = Boolean.class,
+                    description = "Return only the latest alert per trigger")
     })
     @DocResponses(value = {
             @DocResponse(code = 200, message = "Successfully fetched list of alerts.", response = Alert.class, responseContainer = "List"),
@@ -841,6 +845,7 @@ public class AlertsHandler {
         Long startStatusTime = null;
         Long endStatusTime = null;
         boolean thin = false;
+        boolean latestOnly = false;
 
         if (params.get(PARAM_START_TIME) != null) {
             startTime = Long.valueOf(params.get(PARAM_START_TIME));
@@ -893,8 +898,11 @@ public class AlertsHandler {
         if (params.get(PARAM_THIN) != null) {
             thin = Boolean.valueOf(params.get(PARAM_THIN));
         }
+        if (params.get(PARAM_LATEST_ONLY)!=null) {
+            latestOnly = Boolean.valueOf(params.get(PARAM_LATEST_ONLY));
+        }
         return new AlertsCriteria(startTime, endTime, alertIds, triggerIds, statuses, severities,
                 unifiedTagQuery, startResolvedTime, endResolvedTime, startAckTime, endAckTime, startStatusTime,
-                endStatusTime, thin);
+                endStatusTime, thin, latestOnly );
     }
 }

--- a/external/src/main/resources/META-INF/resources/api/policies/v1.0/openapi.json
+++ b/external/src/main/resources/META-INF/resources/api/policies/v1.0/openapi.json
@@ -6,2002 +6,6 @@
         "description": "REST interface to Policies backend engine"
     },
     "paths": {
-        "/triggers/{triggerId}/dampenings": {
-            "post": {
-                "summary": "Create a new dampening.",
-                "description": "Return Dampening created.",
-                "parameters": [
-                    {
-                        "name": "triggerId",
-                        "in": "path",
-                        "description": "Trigger definition id attached to dampening.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Dampening definition to be created.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Dampening"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success, Dampening created.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Dampening"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "get": {
-                "summary": "Get all Dampenings for a Trigger (1 Dampening per mode).",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "triggerId",
-                        "in": "path",
-                        "description": "Trigger definition id to be retrieved.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success, Trigger found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Dampening"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/groups/{groupId}/dampenings": {
-            "post": {
-                "summary": "Create a new group dampening.",
-                "description": "Return group Dampening created.",
-                "parameters": [
-                    {
-                        "name": "groupId",
-                        "in": "path",
-                        "description": "Group Trigger definition id attached to dampening.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Dampening definition to be created.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Dampening"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success, Dampening created.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Dampening"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/trigger": {
-            "post": {
-                "summary": "Create a new full trigger (trigger, dampenings and conditions).",
-                "description": "Return created full trigger.",
-                "parameters": [
-                    {
-                        "name": "dry",
-                        "in": "query",
-                        "description": "Process the trigger (validate), but do not store it.",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "FullTrigger (trigger, dampenings, conditions) to be created.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/FullTrigger"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success, FullTrigger created.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/FullTrigger"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/trigger/{triggerId}": {
-            "put": {
-                "summary": "Update an existing full trigger (trigger, dampenings and conditions).",
-                "description": "Return updated full trigger.",
-                "parameters": [
-                    {
-                        "name": "triggerId",
-                        "in": "path",
-                        "description": "Trigger definition id to be updated.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "dry",
-                        "in": "query",
-                        "description": "Process the trigger (validate), but do not store it.",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "FullTrigger (trigger, dampenings, conditions) to be created.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/FullTrigger"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success, FullTrigger updated.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/FullTrigger"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "get": {
-                "summary": "Get an existing full trigger definition (trigger, dampenings and conditions).",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "triggerId",
-                        "in": "path",
-                        "description": "Trigger definition id to be retrieved.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success, Trigger found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/FullTrigger"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Trigger not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/groups/members": {
-            "post": {
-                "summary": "Create a new member trigger for a parent trigger.",
-                "description": "Returns Member Trigger created if operation finished correctly.",
-                "parameters": [
-                    
-                ],
-                "requestBody": {
-                    "description": "Group member trigger to be created.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/GroupMemberInfo"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success, Member Trigger Created.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Trigger"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Group trigger not found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers": {
-            "post": {
-                "summary": "Create a new trigger.",
-                "description": "Returns created trigger.",
-                "parameters": [
-                    
-                ],
-                "requestBody": {
-                    "description": "Trigger definition to be created.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Trigger"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success, Trigger Created.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Trigger"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "get": {
-                "summary": "Get triggers with optional filtering.",
-                "description": "If not criteria defined, it fetches all triggers stored in the system.",
-                "parameters": [
-                    {
-                        "name": "triggerIds",
-                        "in": "query",
-                        "description": "Filter out triggers for unspecified triggerIds.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "tags",
-                        "in": "query",
-                        "description": "Filter out triggers for unspecified tags.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "thin",
-                        "in": "query",
-                        "description": "Return only thin triggers. Currently Ignored.",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successfully fetched list of triggers.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Trigger"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Trigger not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/groups": {
-            "post": {
-                "summary": "Create a new group trigger.",
-                "description": "Returns created group trigger.",
-                "parameters": [
-                    
-                ],
-                "requestBody": {
-                    "description": "Group member trigger to be created.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Trigger"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success, Group Trigger Created.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Trigger"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/{triggerId}/dampenings/{dampeningId}": {
-            "delete": {
-                "summary": "Delete an existing dampening definition.",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "triggerId",
-                        "in": "path",
-                        "description": "Trigger definition id to be deleted.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "dampeningId",
-                        "in": "path",
-                        "description": "Dampening id for dampening definition to be deleted.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success, Dampening updated.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/FullTrigger"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "get": {
-                "summary": "Get an existing dampening.",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "triggerId",
-                        "in": "path",
-                        "description": "Trigger definition id to be retrieved.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "dampeningId",
-                        "in": "path",
-                        "description": "Dampening id",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successfully fetched list of triggers.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Dampening"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Damppening not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update an existing dampening definition.",
-                "description": "Note that the trigger mode can not be changed. + \nReturn Dampening updated.",
-                "parameters": [
-                    {
-                        "name": "triggerId",
-                        "in": "path",
-                        "description": "Trigger definition id to be retrieved.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "dampeningId",
-                        "in": "path",
-                        "description": "Updated dampening definition.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Updated dampening definition.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Dampening"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success, Dampening Updated.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Dampening"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "No Dampening Found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/groups/{groupId}/dampenings/{dampeningId}": {
-            "delete": {
-                "summary": "Delete an existing group dampening definition.",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "groupId",
-                        "in": "path",
-                        "description": "Group Trigger definition id to be deleted.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "dampeningId",
-                        "in": "path",
-                        "description": "Dampening id for dampening definition to be deleted.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success, Dampening updated.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/FullTrigger"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update an existing group dampening definition.",
-                "description": "Note that the trigger mode can not be changed. + \nReturn Dampening updated.",
-                "parameters": [
-                    {
-                        "name": "groupId",
-                        "in": "path",
-                        "description": "Group trigger definition id to be retrieved.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "dampeningId",
-                        "in": "path",
-                        "description": "Updated dampening definition.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Updated dampening definition.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Dampening"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success, Dampening Updated.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Dampening"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "No Dampening Found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/groups/{groupId}": {
-            "delete": {
-                "summary": "Delete a group trigger.",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "groupId",
-                        "in": "path",
-                        "description": "Group Trigger definition id to be deleted.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "keepNonOrphans",
-                        "in": "query",
-                        "description": "Convert the non-orphan member triggers to standard triggers.",
-                        "required": true,
-                        "schema": {
-                            "type": "boolean"
-                        }
-                    },
-                    {
-                        "name": "keepOrphans",
-                        "in": "query",
-                        "description": "Convert the orphan member triggers to standard triggers.",
-                        "required": true,
-                        "schema": {
-                            "type": "boolean"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success, Group Trigger Removed."
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Group Trigger not found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update an existing group trigger definition and its member definitions.",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "groupId",
-                        "in": "path",
-                        "description": "Group Trigger definition id to be updated.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Updated group trigger definition.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Trigger"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success, Group Trigger updated.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Trigger"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Trigger not found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/{triggerId}": {
-            "delete": {
-                "summary": "Delete an existing standard or group member trigger definition.",
-                "description": "This can not be used to delete a group trigger definition.",
-                "parameters": [
-                    {
-                        "name": "triggerId",
-                        "in": "path",
-                        "description": "Trigger definition id to be deleted.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success, Trigger deleted."
-                    },
-                    "404": {
-                        "description": "Trigger not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "get": {
-                "summary": "Get an existing trigger definition.",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "triggerId",
-                        "in": "path",
-                        "description": "Trigger definition id to be retrieved.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success, Trigger found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Trigger"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Trigger not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "summary": "Update an existing trigger definition.",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "triggerId",
-                        "in": "path",
-                        "description": "Trigger definition id to be updated.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Updated trigger definition.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Trigger"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success, Trigger updated.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Trigger"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Trigger not found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/groups/{groupId}/members": {
-            "get": {
-                "summary": "Find all group member trigger definitions.",
-                "description": "No pagination.",
-                "parameters": [
-                    {
-                        "name": "groupId",
-                        "in": "path",
-                        "description": "Group Trigger definition id.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "includeOrphans",
-                        "in": "query",
-                        "description": "include Orphan members? No if omitted.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successfully fetched list of triggers.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Trigger"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Trigger not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/{triggerId}/conditions": {
-            "get": {
-                "summary": "Get all conditions for a specific trigger.",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "triggerId",
-                        "in": "path",
-                        "description": "Trigger definition id to be retrieved.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successfully fetched list of conditions.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Condition"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "summary": "Set the conditions for the trigger. ",
-                "description": "This sets the conditions for all trigger modes, replacing existing conditions for all trigger modes. Returns the new conditions.",
-                "parameters": [
-                    {
-                        "name": "triggerId",
-                        "in": "path",
-                        "description": "The relevant Trigger.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Collection of Conditions to set.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Condition"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success, Condition Set created.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Condition"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Trigger not found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/{triggerId}/dampenings/mode/{triggerMode}": {
-            "get": {
-                "summary": "Get dampening using triggerId and triggerMode.",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "triggerId",
-                        "in": "path",
-                        "description": "Trigger definition id to be retrieved.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "triggerMode",
-                        "in": "path",
-                        "description": "Trigger mode.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success, Trigger found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Dampening"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/groups/members/{memberId}/orphan": {
-            "put": {
-                "summary": "Make a non-orphan member trigger into an orphan.",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "memberId",
-                        "in": "path",
-                        "description": "Member Trigger id to be made an orphan.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success, Trigger updated.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Trigger"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Trigger not found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/groups/members/{memberId}/unorphan": {
-            "put": {
-                "summary": "Make an orphan member trigger into an group trigger.",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "memberId",
-                        "in": "path",
-                        "description": "Orphan Member Trigger id to be assigned into a group trigger",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Only context and dataIdMap are used when changing back to a non-orphan.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UnorphanMemberInfo"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success, Trigger updated.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Trigger"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Trigger not found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/{triggerId}/conditions/{triggerMode}": {
-            "put": {
-                "summary": "Set the conditions for the trigger. ",
-                "description": "This sets the conditions for the trigger. This replaces any existing conditions. Returns the new conditions.",
-                "parameters": [
-                    {
-                        "name": "triggerId",
-                        "in": "path",
-                        "description": "The relevant Trigger.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "triggerMode",
-                        "in": "path",
-                        "description": "The trigger mode.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Collection of Conditions to set.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Condition"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success, Condition Set created.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Condition"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Trigger not found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/groups/{groupId}/conditions": {
-            "put": {
-                "summary": "Set the conditions for the group trigger. ",
-                "description": "This replaces any existing conditions on the group and member conditions for all trigger modes. + \nReturn the new group conditions.",
-                "parameters": [
-                    {
-                        "name": "groupId",
-                        "in": "path",
-                        "description": "The relevant Group definition id",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Collection of Conditions to set and Map with tokens per dataId on members.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/GroupConditionsInfo"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success, Group Condition Set created.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Condition"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Trigger not found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/groups/{groupId}/conditions/{triggerMode}": {
-            "put": {
-                "summary": "Set the conditions for the group trigger. ",
-                "description": "This replaces any existing conditions on the group and member conditions. Return the new group conditions.",
-                "parameters": [
-                    {
-                        "name": "groupId",
-                        "in": "path",
-                        "description": "The relevant Group definition id.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "triggerMode",
-                        "in": "path",
-                        "description": "FIRING or AUTORESOLVE (not case sensitive)",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Collection of Conditions to set and Map with tokens per dataId on members.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/GroupConditionsInfo"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success, Group Condition Set created.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Condition"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Trigger not found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/enabled": {
-            "put": {
-                "summary": "Update triggers to be enabled or disabled.",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "triggerIds",
-                        "in": "query",
-                        "description": "List of trigger ids to enable or disable",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "enabled",
-                        "in": "query",
-                        "description": "Set enabled or disabled.",
-                        "required": true,
-                        "schema": {
-                            "type": "boolean"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success, Triggers updated."
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Trigger not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/{triggerId}/enable": {
-            "put": {
-                "summary": "Enable trigger.",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "triggerId",
-                        "in": "path",
-                        "description": "Trigger definition id to be enabled.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success, Trigger enabled."
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Trigger not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "summary": "Disable trigger,",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "triggerId",
-                        "in": "path",
-                        "description": "Trigger definition id to be disabled.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success, Trigger disabled."
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Trigger not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/triggers/groups/enabled": {
-            "put": {
-                "summary": "Update group triggers and their member triggers to be enabled or disabled.",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "triggerIds",
-                        "in": "query",
-                        "description": "List of group trigger ids to enable or disable",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "enabled",
-                        "in": "query",
-                        "description": "Set enabled or disabled.",
-                        "required": true,
-                        "schema": {
-                            "type": "boolean"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success, Group Triggers updated."
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Group Trigger not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/import/{strategy}": {
             "post": {
                 "summary": "Import a list of full triggers and action definitions.",
@@ -2062,171 +66,43 @@
                 }
             }
         },
-        "/": {
+        "/events/event/{eventId}": {
             "get": {
-                "summary": "Get alerts with optional filtering",
-                "description": "If not criteria defined, it fetches all alerts available in the system. + \nTags Query language (BNF): + \n[source] \n---- \n<tag_query> ::= ( <expression> | \"(\" <object> \")\" | <object> <logical_operator> <object> ) \n<expression> ::= ( <tag_name> | <not> <tag_name> | <tag_name> <boolean_operator> <tag_value> | <tag_name> <array_operator> <array> ) \n<not> ::= [ \"NOT\" | \"not\" ] \n<logical_operator> ::= [ \"AND\" | \"OR\" | \"and\" | \"or\" ] \n<boolean_operator> ::= [ \"==\" | \"!=\" ] \n<array_operator> ::= [ \"IN\" | \"NOT IN\" | \"in\" | \"not in\" ] \n<array> ::= ( \"[\" \"]\" | \"[\" ( \",\" <tag_value> )* ) \n<tag_name> ::= <identifier> \n<tag_value> ::= ( \"'\" <regexp> \"'\" | <simple_value> ) \n; \n; <identifier> and <simple_value> follow pattern [a-zA-Z_0-9][\\-a-zA-Z_0-9]* \n; <regexp> follows any valid Java Regular Expression format \n---- \n",
+                "summary": "Get an existing Event.",
+                "description": "",
                 "parameters": [
                     {
-                        "name": "startTime",
-                        "in": "query",
-                        "description": "Filter out alerts created before this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "entTime",
-                        "in": "query",
-                        "description": "Filter out alerts created after this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "alertIds",
-                        "in": "query",
-                        "description": "Filter out alerts for unspecified alertIds.",
-                        "required": false,
+                        "name": "eventId",
+                        "in": "path",
+                        "description": "Event id to be deleted.",
+                        "required": true,
                         "schema": {
                             "type": "string"
-                        }
-                    },
-                    {
-                        "name": "triggerIds",
-                        "in": "query",
-                        "description": "Filter out alerts for unspecified triggers. ",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "statuses",
-                        "in": "query",
-                        "description": "Filter out alerts for unspecified lifecycle status.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "severities",
-                        "in": "query",
-                        "description": "Filter out alerts for unspecified severity. ",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "tags",
-                        "in": "query",
-                        "description": "[DEPRECATED] Filter out alerts for unspecified tags.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "tagQuery",
-                        "in": "query",
-                        "description": "Filter out alerts for unspecified tags.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "startResolvedTime",
-                        "in": "query",
-                        "description": "Filter out alerts resolved before this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "endResolvedTime",
-                        "in": "query",
-                        "description": "Filter out alerts resolved after this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "startAckTime",
-                        "in": "query",
-                        "description": "Filter out alerts acknowledged before this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "endAckTime",
-                        "in": "query",
-                        "description": "Filter out alerts acknowledged after this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "startStatusTime",
-                        "in": "query",
-                        "description": "Filter out alerts with some lifecycle state before this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "endStatusTime",
-                        "in": "query",
-                        "description": "Filter out alerts with some lifecycle after this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
                         }
                     },
                     {
                         "name": "thin",
                         "in": "query",
-                        "description": "Return only thin alerts, do not include: evalSets, resolvedEvalSets.",
+                        "description": "Return only a thin event, do not include: evalSets, dampening.",
                         "required": false,
                         "schema": {
-                            "type": "boolean"
+                            "type": "string"
                         }
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successfully fetched list of alerts.",
+                        "description": "Success, Event found.",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Alert"
-                                    }
+                                    "$ref": "#/components/schemas/Event"
                                 }
                             }
                         }
                     },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters",
+                    "404": {
+                        "description": "Event not found.",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2248,168 +124,47 @@
                 }
             }
         },
-        "/watch": {
-            "get": {
-                "summary": "Get alerts with optional filtering",
-                "description": "Return a stream of alerts ordered by the current lifecycle stime. + \nChanges on lifecycle alert are monitored and sent by the watcher. + \n + \nIf not criteria defined, it fetches all alerts available in the system. + \n + \nTime criterias are used only for the initial query. + \nAfter initial query, time criterias are discarded, watching alerts by current lifecycle stime. + \nNon time criterias are active. + \n + \nIf not criteria defined, it fetches all alerts available in the system. + \nTags Query language (BNF): + \n[source] \n---- \n<tag_query> ::= ( <expression> | \"(\" <object> \")\" | <object> <logical_operator> <object> ) \n<expression> ::= ( <tag_name> | <not> <tag_name> | <tag_name> <boolean_operator> <tag_value> | <tag_name> <array_operator> <array> ) \n<not> ::= [ \"NOT\" | \"not\" ] \n<logical_operator> ::= [ \"AND\" | \"OR\" | \"and\" | \"or\" ] \n<boolean_operator> ::= [ \"==\" | \"!=\" ] \n<array_operator> ::= [ \"IN\" | \"NOT IN\" | \"in\" | \"not in\" ] \n<array> ::= ( \"[\" \"]\" | \"[\" ( \",\" <tag_value> )* ) \n<tag_name> ::= <identifier> \n<tag_value> ::= ( \"'\" <regexp> \"'\" | <simple_value> ) \n; \n; <identifier> and <simple_value> follow pattern [a-zA-Z_0-9][\\-a-zA-Z_0-9]* \n; <regexp> follows any valid Java Regular Expression format \n---- \n",
+        "/events/data": {
+            "post": {
+                "summary": "Send events to the engine for processing/condition evaluation. ",
+                "description": "Only events generated by the engine are persisted. + \nInput events are treated as external data and those are not persisted into the system.",
                 "parameters": [
-                    {
-                        "name": "startTime",
-                        "in": "query",
-                        "description": "Filter out alerts created before this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "entTime",
-                        "in": "query",
-                        "description": "Filter out alerts created after this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "alertIds",
-                        "in": "query",
-                        "description": "Filter out alerts for unspecified alertIds.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "triggerIds",
-                        "in": "query",
-                        "description": "Filter out alerts for unspecified triggers. ",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "statuses",
-                        "in": "query",
-                        "description": "Filter out alerts for unspecified lifecycle status.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "severities",
-                        "in": "query",
-                        "description": "Filter out alerts for unspecified severity. ",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "tags",
-                        "in": "query",
-                        "description": "[DEPRECATED] Filter out alerts for unspecified tags.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "tagQuery",
-                        "in": "query",
-                        "description": "Filter out alerts for unspecified tags.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "startResolvedTime",
-                        "in": "query",
-                        "description": "Filter out alerts resolved before this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "endResolvedTime",
-                        "in": "query",
-                        "description": "Filter out alerts resolved after this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "startAckTime",
-                        "in": "query",
-                        "description": "Filter out alerts acknowledged before this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "endAckTime",
-                        "in": "query",
-                        "description": "Filter out alerts acknowledged after this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "startStatusTime",
-                        "in": "query",
-                        "description": "Filter out alerts with some lifecycle state before this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "endStatusTime",
-                        "in": "query",
-                        "description": "Filter out alerts with some lifecycle after this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "watchInterval",
-                        "in": "query",
-                        "description": "Define interval when watcher notifications will be sent.",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "thin",
-                        "in": "query",
-                        "description": "Return only thin alerts, do not include: evalSets, resolvedEvalSets.",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean"
+                    
+                ],
+                "requestBody": {
+                    "description": "Events to be processed by alerting.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Event"
+                            }
                         }
                     }
-                ],
+                },
                 "responses": {
                     "200": {
-                        "description": "Errors will close the stream. Description is sent before stream is closed.",
+                        "description": "Success, Events Sent.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Event"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2421,15 +176,15 @@
                 }
             }
         },
-        "/tags": {
+        "/events/tags": {
             "put": {
-                "summary": "Add tags to existing Alerts.",
+                "summary": "Add tags to existing Events.",
                 "description": "",
                 "parameters": [
                     {
-                        "name": "alertIds",
+                        "name": "eventIds",
                         "in": "query",
-                        "description": "List of alerts to tag.",
+                        "description": "List of eventIds to tag.",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -2447,7 +202,14 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success, Alerts tagged successfully."
+                        "description": "Success, Events tagged successfully.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Event"
+                                }
+                            }
+                        }
                     },
                     "400": {
                         "description": "Bad Request/Invalid Parameters.",
@@ -2472,13 +234,13 @@
                 }
             },
             "delete": {
-                "summary": "Remove tags from existing Alerts.",
+                "summary": "Remove tags from existing Events.",
                 "description": "",
                 "parameters": [
                     {
-                        "name": "alertIds",
+                        "name": "eventIds",
                         "in": "query",
-                        "description": "List of alerts to untag.",
+                        "description": "List of eventIds to untag.",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -2496,7 +258,14 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success, Tags deleted successfully."
+                        "description": "Success, Events untagged successfully.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Event"
+                                }
+                            }
+                        }
                     },
                     "400": {
                         "description": "Bad Request/Invalid Parameters.",
@@ -2504,6 +273,501 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/events": {
+            "get": {
+                "summary": "Get events with optional filtering.",
+                "description": "If not criteria defined, it fetches all events stored in the system. + \nTags Query language (BNF): + \n[source] \n---- \n<tag_query> ::= ( <expression> | \"(\" <object> \")\" | <object> <logical_operator> <object> ) \n<expression> ::= ( <tag_name> | <not> <tag_name> | <tag_name> <boolean_operator> <tag_value> | <tag_name> <array_operator> <array> ) \n<not> ::= [ \"NOT\" | \"not\" ] \n<logical_operator> ::= [ \"AND\" | \"OR\" | \"and\" | \"or\" ] \n<boolean_operator> ::= [ \"==\" | \"!=\" ] \n<array_operator> ::= [ \"IN\" | \"NOT IN\" | \"in\" | \"not in\" ] \n<array> ::= ( \"[\" \"]\" | \"[\" ( \",\" <tag_value> )* ) \n<tag_name> ::= <identifier> \n<tag_value> ::= ( \"'\" <regexp> \"'\" | <simple_value> ) \n; \n; <identifier> and <simple_value> follow pattern [a-zA-Z_0-9][\\-a-zA-Z_0-9]* \n; <regexp> follows any valid Java Regular Expression format \n---- \n",
+                "parameters": [
+                    {
+                        "name": "startTime",
+                        "in": "query",
+                        "description": "Filter out events created before this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "endTime",
+                        "in": "query",
+                        "description": "Filter out events created after this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "eventIds",
+                        "in": "query",
+                        "description": "Filter out events for unspecified eventIds.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "triggerIds",
+                        "in": "query",
+                        "description": "Filter out events for unspecified triggers.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "categories",
+                        "in": "query",
+                        "description": "Filter out events for unspecified categories.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "[DEPRECATED] Filter out events for unspecified tags.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tagQuery",
+                        "in": "query",
+                        "description": "Filter out events for unspecified tags.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "thin",
+                        "in": "query",
+                        "description": "Return only thin events, do not include: evalSets.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully fetched list of events.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Event"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "summary": "Create a new Event.",
+                "description": "Persist the new event and send it to the engine for processing/condition evaluation. + \nReturns created Event.",
+                "parameters": [
+                    
+                ],
+                "requestBody": {
+                    "description": "Event to be created. Category and Text fields required.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Event"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success, Event Created.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Event"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/events/watch": {
+            "get": {
+                "summary": "Watch events with optional filtering.",
+                "description": "Return a stream of events ordered by ctime. + \n + \nIf not criteria defined, it fetches all events stored in the system. + \nTags Query language (BNF): + \n[source] \n---- \n<tag_query> ::= ( <expression> | \"(\" <object> \")\" | <object> <logical_operator> <object> ) \n<expression> ::= ( <tag_name> | <not> <tag_name> | <tag_name> <boolean_operator> <tag_value> | <tag_name> <array_operator> <array> ) \n<not> ::= [ \"NOT\" | \"not\" ] \n<logical_operator> ::= [ \"AND\" | \"OR\" | \"and\" | \"or\" ] \n<boolean_operator> ::= [ \"==\" | \"!=\" ] \n<array_operator> ::= [ \"IN\" | \"NOT IN\" | \"in\" | \"not in\" ] \n<array> ::= ( \"[\" \"]\" | \"[\" ( \",\" <tag_value> )* ) \n<tag_name> ::= <identifier> \n<tag_value> ::= ( \"'\" <regexp> \"'\" | <simple_value> ) \n; \n; <identifier> and <simple_value> follow pattern [a-zA-Z_0-9][\\-a-zA-Z_0-9]* \n; <regexp> follows any valid Java Regular Expression format \n---- \n",
+                "parameters": [
+                    {
+                        "name": "startTime",
+                        "in": "query",
+                        "description": "Filter out events created before this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "endTime",
+                        "in": "query",
+                        "description": "Filter out events created after this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "eventIds",
+                        "in": "query",
+                        "description": "Filter out events for unspecified eventIds.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "triggerIds",
+                        "in": "query",
+                        "description": "Filter out events for unspecified triggers.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "categories",
+                        "in": "query",
+                        "description": "Filter out events for unspecified categories.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "[DEPRECATED] Filter out events for unspecified tags.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tagQuery",
+                        "in": "query",
+                        "description": "Filter out events for unspecified tags.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "watchInterval",
+                        "in": "query",
+                        "description": "Define interval when watcher notifications will be sent.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "thin",
+                        "in": "query",
+                        "description": "Return only thin events, do not include: evalSets.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Errors will close the stream. Description is sent before stream is closed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/events/delete": {
+            "put": {
+                "summary": "Delete events with optional filtering.",
+                "description": "Return number of events deleted. + \nWARNING: If not criteria defined, it deletes all events stored in the system. + \nTags Query language (BNF): + \n[source] \n---- \n<tag_query> ::= ( <expression> | \"(\" <object> \")\" | <object> <logical_operator> <object> ) \n<expression> ::= ( <tag_name> | <not> <tag_name> | <tag_name> <boolean_operator> <tag_value> | <tag_name> <array_operator> <array> ) \n<not> ::= [ \"NOT\" | \"not\" ] \n<logical_operator> ::= [ \"AND\" | \"OR\" | \"and\" | \"or\" ] \n<boolean_operator> ::= [ \"==\" | \"!=\" ] \n<array_operator> ::= [ \"IN\" | \"NOT IN\" | \"in\" | \"not in\" ] \n<array> ::= ( \"[\" \"]\" | \"[\" ( \",\" <tag_value> )* ) \n<tag_name> ::= <identifier> \n<tag_value> ::= ( \"'\" <regexp> \"'\" | <simple_value> ) \n; \n; <identifier> and <simple_value> follow pattern [a-zA-Z_0-9][\\-a-zA-Z_0-9]* \n; <regexp> follows any valid Java Regular Expression format \n---- \n",
+                "parameters": [
+                    {
+                        "name": "startTime",
+                        "in": "query",
+                        "description": "Filter out events created before this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "endTime",
+                        "in": "query",
+                        "description": "Filter out events created after this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "eventIds",
+                        "in": "query",
+                        "description": "Filter out events for unspecified eventIds.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "triggerIds",
+                        "in": "query",
+                        "description": "Filter out events for unspecified triggers.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "categories",
+                        "in": "query",
+                        "description": "Filter out events for unspecified categories.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "[DEPRECATED] Filter out events for unspecified tags.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tagQuery",
+                        "in": "query",
+                        "description": "Filter out events for unspecified tags.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success. Number of events deleted.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiDeleted"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/events/{eventId}": {
+            "delete": {
+                "summary": "Delete an existing Event.",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "eventId",
+                        "in": "path",
+                        "description": "Event id to be deleted.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success, Event deleted."
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/plugins/{actionPlugin}": {
+            "get": {
+                "summary": "Find list of properties to fill for a specific action plugin.",
+                "description": "Each action plugin can have a different and variable number of properties. + \nThis method should be invoked before of a creation of a new action.",
+                "parameters": [
+                    {
+                        "name": "actionPlugin",
+                        "in": "path",
+                        "description": "Action plugin to query.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success, Action Plugin found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Action Plugin not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/plugins": {
+            "get": {
+                "summary": "Find all action plugins.",
+                "description": "",
+                "responses": {
+                    "200": {
+                        "description": "Successfully fetched list of actions plugins.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
                                 }
                             }
                         }
@@ -2764,38 +1028,37 @@
                 }
             }
         },
-        "/{alertId}": {
-            "delete": {
-                "summary": "Delete an existing Alert.",
+        "/alert/{alertId}": {
+            "put": {
+                "summary": "Get an existing Alert.",
                 "description": "",
                 "parameters": [
                     {
                         "name": "alertId",
                         "in": "path",
-                        "description": "Alert id to be deleted.",
+                        "description": "Get an existing Alert.",
                         "required": true,
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    {
+                        "name": "thin",
+                        "in": "query",
+                        "description": "Return only a thin alert, do not include: evalSets, resolvedEvalSets.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
                         }
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success, Alerts deleted.",
+                        "description": "Success, Alert found.",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ApiDeleted"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
+                                    "$ref": "#/components/schemas/Alert"
                                 }
                             }
                         }
@@ -2832,66 +1095,6 @@
                         "name": "alertIds",
                         "in": "query",
                         "description": "List of alerts to set resolved.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "resolvedBy",
-                        "in": "query",
-                        "description": "User resolving the alerts.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "resolvedNotes",
-                        "in": "query",
-                        "description": "Additional notes associated with the resolution.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success, Alerts Resolution invoked successfully."
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/resolve/{alertId}": {
-            "put": {
-                "summary": "Set one alert resolved.",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "alertId",
-                        "in": "path",
-                        "description": "The alertId to set resolved.",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -2988,24 +1191,158 @@
                 }
             }
         },
-        "/alert/{alertId}": {
-            "put": {
-                "summary": "Get an existing Alert.",
-                "description": "",
+        "/": {
+            "get": {
+                "summary": "Get alerts with optional filtering",
+                "description": "If not criteria defined, it fetches all alerts available in the system. + \nTags Query language (BNF): + \n[source] \n---- \n<tag_query> ::= ( <expression> | \"(\" <object> \")\" | <object> <logical_operator> <object> ) \n<expression> ::= ( <tag_name> | <not> <tag_name> | <tag_name> <boolean_operator> <tag_value> | <tag_name> <array_operator> <array> ) \n<not> ::= [ \"NOT\" | \"not\" ] \n<logical_operator> ::= [ \"AND\" | \"OR\" | \"and\" | \"or\" ] \n<boolean_operator> ::= [ \"==\" | \"!=\" ] \n<array_operator> ::= [ \"IN\" | \"NOT IN\" | \"in\" | \"not in\" ] \n<array> ::= ( \"[\" \"]\" | \"[\" ( \",\" <tag_value> )* ) \n<tag_name> ::= <identifier> \n<tag_value> ::= ( \"'\" <regexp> \"'\" | <simple_value> ) \n; \n; <identifier> and <simple_value> follow pattern [a-zA-Z_0-9][\\-a-zA-Z_0-9]* \n; <regexp> follows any valid Java Regular Expression format \n---- \n",
                 "parameters": [
                     {
-                        "name": "alertId",
-                        "in": "path",
-                        "description": "Get an existing Alert.",
-                        "required": true,
+                        "name": "startTime",
+                        "in": "query",
+                        "description": "Filter out alerts created before this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "endTime",
+                        "in": "query",
+                        "description": "Filter out alerts created after this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "alertIds",
+                        "in": "query",
+                        "description": "Filter out alerts for unspecified alertIds.",
+                        "required": false,
                         "schema": {
                             "type": "string"
                         }
                     },
                     {
+                        "name": "triggerIds",
+                        "in": "query",
+                        "description": "Filter out alerts for unspecified triggers. ",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "statuses",
+                        "in": "query",
+                        "description": "Filter out alerts for unspecified lifecycle status.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "severities",
+                        "in": "query",
+                        "description": "Filter out alerts for unspecified severity. ",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "[DEPRECATED] Filter out alerts for unspecified tags.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tagQuery",
+                        "in": "query",
+                        "description": "Filter out alerts for unspecified tags.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "startResolvedTime",
+                        "in": "query",
+                        "description": "Filter out alerts resolved before this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "endResolvedTime",
+                        "in": "query",
+                        "description": "Filter out alerts resolved after this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "startAckTime",
+                        "in": "query",
+                        "description": "Filter out alerts acknowledged before this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "endAckTime",
+                        "in": "query",
+                        "description": "Filter out alerts acknowledged after this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "startStatusTime",
+                        "in": "query",
+                        "description": "Filter out alerts with some lifecycle state before this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "endStatusTime",
+                        "in": "query",
+                        "description": "Filter out alerts with some lifecycle after this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
                         "name": "thin",
                         "in": "query",
-                        "description": "Return only a thin alert, do not include: evalSets, resolvedEvalSets.",
+                        "description": "Return only thin alerts, do not include: evalSets, resolvedEvalSets.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "name": "latestOnly",
+                        "in": "query",
+                        "description": "Return only the latest alert per trigger",
                         "required": false,
                         "schema": {
                             "type": "boolean"
@@ -3014,17 +1351,312 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success, Alert found.",
+                        "description": "Successfully fetched list of alerts.",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Alert"
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Alert"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/watch": {
+            "get": {
+                "summary": "Get alerts with optional filtering",
+                "description": "Return a stream of alerts ordered by the current lifecycle stime. + \nChanges on lifecycle alert are monitored and sent by the watcher. + \n + \nIf not criteria defined, it fetches all alerts available in the system. + \n + \nTime criterias are used only for the initial query. + \nAfter initial query, time criterias are discarded, watching alerts by current lifecycle stime. + \nNon time criterias are active. + \n + \nIf not criteria defined, it fetches all alerts available in the system. + \nTags Query language (BNF): + \n[source] \n---- \n<tag_query> ::= ( <expression> | \"(\" <object> \")\" | <object> <logical_operator> <object> ) \n<expression> ::= ( <tag_name> | <not> <tag_name> | <tag_name> <boolean_operator> <tag_value> | <tag_name> <array_operator> <array> ) \n<not> ::= [ \"NOT\" | \"not\" ] \n<logical_operator> ::= [ \"AND\" | \"OR\" | \"and\" | \"or\" ] \n<boolean_operator> ::= [ \"==\" | \"!=\" ] \n<array_operator> ::= [ \"IN\" | \"NOT IN\" | \"in\" | \"not in\" ] \n<array> ::= ( \"[\" \"]\" | \"[\" ( \",\" <tag_value> )* ) \n<tag_name> ::= <identifier> \n<tag_value> ::= ( \"'\" <regexp> \"'\" | <simple_value> ) \n; \n; <identifier> and <simple_value> follow pattern [a-zA-Z_0-9][\\-a-zA-Z_0-9]* \n; <regexp> follows any valid Java Regular Expression format \n---- \n",
+                "parameters": [
+                    {
+                        "name": "startTime",
+                        "in": "query",
+                        "description": "Filter out alerts created before this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "entTime",
+                        "in": "query",
+                        "description": "Filter out alerts created after this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "alertIds",
+                        "in": "query",
+                        "description": "Filter out alerts for unspecified alertIds.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "triggerIds",
+                        "in": "query",
+                        "description": "Filter out alerts for unspecified triggers. ",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "statuses",
+                        "in": "query",
+                        "description": "Filter out alerts for unspecified lifecycle status.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "severities",
+                        "in": "query",
+                        "description": "Filter out alerts for unspecified severity. ",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "[DEPRECATED] Filter out alerts for unspecified tags.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tagQuery",
+                        "in": "query",
+                        "description": "Filter out alerts for unspecified tags.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "startResolvedTime",
+                        "in": "query",
+                        "description": "Filter out alerts resolved before this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "endResolvedTime",
+                        "in": "query",
+                        "description": "Filter out alerts resolved after this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "startAckTime",
+                        "in": "query",
+                        "description": "Filter out alerts acknowledged before this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "endAckTime",
+                        "in": "query",
+                        "description": "Filter out alerts acknowledged after this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "startStatusTime",
+                        "in": "query",
+                        "description": "Filter out alerts with some lifecycle state before this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "endStatusTime",
+                        "in": "query",
+                        "description": "Filter out alerts with some lifecycle after this time.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "watchInterval",
+                        "in": "query",
+                        "description": "Define interval when watcher notifications will be sent.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "thin",
+                        "in": "query",
+                        "description": "Return only thin alerts, do not include: evalSets, resolvedEvalSets.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Errors will close the stream. Description is sent before stream is closed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/{alertId}": {
+            "delete": {
+                "summary": "Delete an existing Alert.",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "alertId",
+                        "in": "path",
+                        "description": "Alert id to be deleted.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success, Alerts deleted.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiDeleted"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
                                 }
                             }
                         }
                     },
                     "404": {
                         "description": "Alert not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/resolve/{alertId}": {
+            "put": {
+                "summary": "Set one alert resolved.",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "alertId",
+                        "in": "path",
+                        "description": "The alertId to set resolved.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "resolvedBy",
+                        "in": "query",
+                        "description": "User resolving the alerts.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "resolvedNotes",
+                        "in": "query",
+                        "description": "Additional notes associated with the resolution.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success, Alerts Resolution invoked successfully."
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3166,15 +1798,15 @@
                 }
             }
         },
-        "/events/tags": {
+        "/tags": {
             "put": {
-                "summary": "Add tags to existing Events.",
+                "summary": "Add tags to existing Alerts.",
                 "description": "",
                 "parameters": [
                     {
-                        "name": "eventIds",
+                        "name": "alertIds",
                         "in": "query",
-                        "description": "List of eventIds to tag.",
+                        "description": "List of alerts to tag.",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -3192,14 +1824,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success, Events tagged successfully.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Event"
-                                }
-                            }
-                        }
+                        "description": "Success, Alerts tagged successfully."
                     },
                     "400": {
                         "description": "Bad Request/Invalid Parameters.",
@@ -3224,13 +1849,13 @@
                 }
             },
             "delete": {
-                "summary": "Remove tags from existing Events.",
+                "summary": "Remove tags from existing Alerts.",
                 "description": "",
                 "parameters": [
                     {
-                        "name": "eventIds",
+                        "name": "alertIds",
                         "in": "query",
-                        "description": "List of eventIds to untag.",
+                        "description": "List of alerts to untag.",
                         "required": true,
                         "schema": {
                             "type": "string"
@@ -3248,536 +1873,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success, Events untagged successfully.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Event"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/events/delete": {
-            "put": {
-                "summary": "Delete events with optional filtering.",
-                "description": "Return number of events deleted. + \nWARNING: If not criteria defined, it deletes all events stored in the system. + \nTags Query language (BNF): + \n[source] \n---- \n<tag_query> ::= ( <expression> | \"(\" <object> \")\" | <object> <logical_operator> <object> ) \n<expression> ::= ( <tag_name> | <not> <tag_name> | <tag_name> <boolean_operator> <tag_value> | <tag_name> <array_operator> <array> ) \n<not> ::= [ \"NOT\" | \"not\" ] \n<logical_operator> ::= [ \"AND\" | \"OR\" | \"and\" | \"or\" ] \n<boolean_operator> ::= [ \"==\" | \"!=\" ] \n<array_operator> ::= [ \"IN\" | \"NOT IN\" | \"in\" | \"not in\" ] \n<array> ::= ( \"[\" \"]\" | \"[\" ( \",\" <tag_value> )* ) \n<tag_name> ::= <identifier> \n<tag_value> ::= ( \"'\" <regexp> \"'\" | <simple_value> ) \n; \n; <identifier> and <simple_value> follow pattern [a-zA-Z_0-9][\\-a-zA-Z_0-9]* \n; <regexp> follows any valid Java Regular Expression format \n---- \n",
-                "parameters": [
-                    {
-                        "name": "startTime",
-                        "in": "query",
-                        "description": "Filter out events created before this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "endTime",
-                        "in": "query",
-                        "description": "Filter out events created after this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "eventIds",
-                        "in": "query",
-                        "description": "Filter out events for unspecified eventIds.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "triggerIds",
-                        "in": "query",
-                        "description": "Filter out events for unspecified triggers.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "categories",
-                        "in": "query",
-                        "description": "Filter out events for unspecified categories.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "tags",
-                        "in": "query",
-                        "description": "[DEPRECATED] Filter out events for unspecified tags.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "tagQuery",
-                        "in": "query",
-                        "description": "Filter out events for unspecified tags.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success. Number of events deleted.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiDeleted"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/events/event/{eventId}": {
-            "get": {
-                "summary": "Get an existing Event.",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "eventId",
-                        "in": "path",
-                        "description": "Event id to be deleted.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "thin",
-                        "in": "query",
-                        "description": "Return only a thin event, do not include: evalSets, dampening.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success, Event found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Event"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Event not found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/events/data": {
-            "post": {
-                "summary": "Send events to the engine for processing/condition evaluation. ",
-                "description": "Only events generated by the engine are persisted. + \nInput events are treated as external data and those are not persisted into the system.",
-                "parameters": [
-                    
-                ],
-                "requestBody": {
-                    "description": "Events to be processed by alerting.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Event"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success, Events Sent.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Event"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/events": {
-            "post": {
-                "summary": "Create a new Event.",
-                "description": "Persist the new event and send it to the engine for processing/condition evaluation. + \nReturns created Event.",
-                "parameters": [
-                    
-                ],
-                "requestBody": {
-                    "description": "Event to be created. Category and Text fields required.",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Event"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success, Event Created.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Event"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "get": {
-                "summary": "Get events with optional filtering.",
-                "description": "If not criteria defined, it fetches all events stored in the system. + \nTags Query language (BNF): + \n[source] \n---- \n<tag_query> ::= ( <expression> | \"(\" <object> \")\" | <object> <logical_operator> <object> ) \n<expression> ::= ( <tag_name> | <not> <tag_name> | <tag_name> <boolean_operator> <tag_value> | <tag_name> <array_operator> <array> ) \n<not> ::= [ \"NOT\" | \"not\" ] \n<logical_operator> ::= [ \"AND\" | \"OR\" | \"and\" | \"or\" ] \n<boolean_operator> ::= [ \"==\" | \"!=\" ] \n<array_operator> ::= [ \"IN\" | \"NOT IN\" | \"in\" | \"not in\" ] \n<array> ::= ( \"[\" \"]\" | \"[\" ( \",\" <tag_value> )* ) \n<tag_name> ::= <identifier> \n<tag_value> ::= ( \"'\" <regexp> \"'\" | <simple_value> ) \n; \n; <identifier> and <simple_value> follow pattern [a-zA-Z_0-9][\\-a-zA-Z_0-9]* \n; <regexp> follows any valid Java Regular Expression format \n---- \n",
-                "parameters": [
-                    {
-                        "name": "startTime",
-                        "in": "query",
-                        "description": "Filter out events created before this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "endTime",
-                        "in": "query",
-                        "description": "Filter out events created after this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "eventIds",
-                        "in": "query",
-                        "description": "Filter out events for unspecified eventIds.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "triggerIds",
-                        "in": "query",
-                        "description": "Filter out events for unspecified triggers.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "categories",
-                        "in": "query",
-                        "description": "Filter out events for unspecified categories.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "tags",
-                        "in": "query",
-                        "description": "[DEPRECATED] Filter out events for unspecified tags.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "tagQuery",
-                        "in": "query",
-                        "description": "Filter out events for unspecified tags.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "thin",
-                        "in": "query",
-                        "description": "Return only thin events, do not include: evalSets.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successfully fetched list of events.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Event"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request/Invalid Parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/events/watch": {
-            "get": {
-                "summary": "Watch events with optional filtering.",
-                "description": "Return a stream of events ordered by ctime. + \n + \nIf not criteria defined, it fetches all events stored in the system. + \nTags Query language (BNF): + \n[source] \n---- \n<tag_query> ::= ( <expression> | \"(\" <object> \")\" | <object> <logical_operator> <object> ) \n<expression> ::= ( <tag_name> | <not> <tag_name> | <tag_name> <boolean_operator> <tag_value> | <tag_name> <array_operator> <array> ) \n<not> ::= [ \"NOT\" | \"not\" ] \n<logical_operator> ::= [ \"AND\" | \"OR\" | \"and\" | \"or\" ] \n<boolean_operator> ::= [ \"==\" | \"!=\" ] \n<array_operator> ::= [ \"IN\" | \"NOT IN\" | \"in\" | \"not in\" ] \n<array> ::= ( \"[\" \"]\" | \"[\" ( \",\" <tag_value> )* ) \n<tag_name> ::= <identifier> \n<tag_value> ::= ( \"'\" <regexp> \"'\" | <simple_value> ) \n; \n; <identifier> and <simple_value> follow pattern [a-zA-Z_0-9][\\-a-zA-Z_0-9]* \n; <regexp> follows any valid Java Regular Expression format \n---- \n",
-                "parameters": [
-                    {
-                        "name": "startTime",
-                        "in": "query",
-                        "description": "Filter out events created before this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "endTime",
-                        "in": "query",
-                        "description": "Filter out events created after this time.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "eventIds",
-                        "in": "query",
-                        "description": "Filter out events for unspecified eventIds.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "triggerIds",
-                        "in": "query",
-                        "description": "Filter out events for unspecified triggers.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "categories",
-                        "in": "query",
-                        "description": "Filter out events for unspecified categories.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "tags",
-                        "in": "query",
-                        "description": "[DEPRECATED] Filter out events for unspecified tags.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "tagQuery",
-                        "in": "query",
-                        "description": "Filter out events for unspecified tags.",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "watchInterval",
-                        "in": "query",
-                        "description": "Define interval when watcher notifications will be sent.",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "thin",
-                        "in": "query",
-                        "description": "Return only thin events, do not include: evalSets.",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Errors will close the stream. Description is sent before stream is closed.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/events/{eventId}": {
-            "delete": {
-                "summary": "Delete an existing Event.",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "eventId",
-                        "in": "path",
-                        "description": "Event id to be deleted.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success, Event deleted."
+                        "description": "Success, Tags deleted successfully."
                     },
                     "400": {
                         "description": "Bad Request/Invalid Parameters.",
@@ -3813,89 +1909,6 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/Definitions"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/plugins/{actionPlugin}": {
-            "get": {
-                "summary": "Find list of properties to fill for a specific action plugin.",
-                "description": "Each action plugin can have a different and variable number of properties. + \nThis method should be invoked before of a creation of a new action.",
-                "parameters": [
-                    {
-                        "name": "actionPlugin",
-                        "in": "path",
-                        "description": "Action plugin to query.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success, Action Plugin found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Action Plugin not found.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/plugins": {
-            "get": {
-                "summary": "Find all action plugins.",
-                "description": "",
-                "responses": {
-                    "200": {
-                        "description": "Successfully fetched list of actions plugins.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
                                 }
                             }
                         }
@@ -4394,113 +2407,2006 @@
                     }
                 }
             }
+        },
+        "/triggers/trigger": {
+            "post": {
+                "summary": "Create a new full trigger (trigger, dampenings and conditions).",
+                "description": "Return created full trigger.",
+                "parameters": [
+                    {
+                        "name": "dry",
+                        "in": "query",
+                        "description": "Process the trigger (validate), but do not store it.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "FullTrigger (trigger, dampenings, conditions) to be created.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FullTrigger"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success, FullTrigger created.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FullTrigger"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/trigger/{triggerId}": {
+            "get": {
+                "summary": "Get an existing full trigger definition (trigger, dampenings and conditions).",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "triggerId",
+                        "in": "path",
+                        "description": "Trigger definition id to be retrieved.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success, Trigger found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FullTrigger"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Trigger not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "summary": "Update an existing full trigger (trigger, dampenings and conditions).",
+                "description": "Return updated full trigger.",
+                "parameters": [
+                    {
+                        "name": "triggerId",
+                        "in": "path",
+                        "description": "Trigger definition id to be updated.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "dry",
+                        "in": "query",
+                        "description": "Process the trigger (validate), but do not store it.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "FullTrigger (trigger, dampenings, conditions) to be created.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FullTrigger"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success, FullTrigger updated.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FullTrigger"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/{triggerId}": {
+            "put": {
+                "summary": "Update an existing trigger definition.",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "triggerId",
+                        "in": "path",
+                        "description": "Trigger definition id to be updated.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Updated trigger definition.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Trigger"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success, Trigger updated.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Trigger"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Trigger not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "summary": "Get an existing trigger definition.",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "triggerId",
+                        "in": "path",
+                        "description": "Trigger definition id to be retrieved.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success, Trigger found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Trigger"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Trigger not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete an existing standard or group member trigger definition.",
+                "description": "This can not be used to delete a group trigger definition.",
+                "parameters": [
+                    {
+                        "name": "triggerId",
+                        "in": "path",
+                        "description": "Trigger definition id to be deleted.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success, Trigger deleted."
+                    },
+                    "404": {
+                        "description": "Trigger not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/groups/{groupId}": {
+            "put": {
+                "summary": "Update an existing group trigger definition and its member definitions.",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "groupId",
+                        "in": "path",
+                        "description": "Group Trigger definition id to be updated.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Updated group trigger definition.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Trigger"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success, Group Trigger updated.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Trigger"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Trigger not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete a group trigger.",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "groupId",
+                        "in": "path",
+                        "description": "Group Trigger definition id to be deleted.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "keepNonOrphans",
+                        "in": "query",
+                        "description": "Convert the non-orphan member triggers to standard triggers.",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "name": "keepOrphans",
+                        "in": "query",
+                        "description": "Convert the orphan member triggers to standard triggers.",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success, Group Trigger Removed."
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Group Trigger not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/groups/members/{memberId}/orphan": {
+            "put": {
+                "summary": "Make a non-orphan member trigger into an orphan.",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "memberId",
+                        "in": "path",
+                        "description": "Member Trigger id to be made an orphan.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success, Trigger updated.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Trigger"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Trigger not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/groups/members/{memberId}/unorphan": {
+            "put": {
+                "summary": "Make an orphan member trigger into an group trigger.",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "memberId",
+                        "in": "path",
+                        "description": "Orphan Member Trigger id to be assigned into a group trigger",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Only context and dataIdMap are used when changing back to a non-orphan.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UnorphanMemberInfo"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success, Trigger updated.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Trigger"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Trigger not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/{triggerId}/dampenings/{dampeningId}": {
+            "put": {
+                "summary": "Update an existing dampening definition.",
+                "description": "Note that the trigger mode can not be changed. + \nReturn Dampening updated.",
+                "parameters": [
+                    {
+                        "name": "triggerId",
+                        "in": "path",
+                        "description": "Trigger definition id to be retrieved.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "dampeningId",
+                        "in": "path",
+                        "description": "Updated dampening definition.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Updated dampening definition.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Dampening"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success, Dampening Updated.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Dampening"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No Dampening Found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "summary": "Get an existing dampening.",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "triggerId",
+                        "in": "path",
+                        "description": "Trigger definition id to be retrieved.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "dampeningId",
+                        "in": "path",
+                        "description": "Dampening id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully fetched list of triggers.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Dampening"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Damppening not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete an existing dampening definition.",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "triggerId",
+                        "in": "path",
+                        "description": "Trigger definition id to be deleted.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "dampeningId",
+                        "in": "path",
+                        "description": "Dampening id for dampening definition to be deleted.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success, Dampening updated.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FullTrigger"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/groups/{groupId}/dampenings/{dampeningId}": {
+            "put": {
+                "summary": "Update an existing group dampening definition.",
+                "description": "Note that the trigger mode can not be changed. + \nReturn Dampening updated.",
+                "parameters": [
+                    {
+                        "name": "groupId",
+                        "in": "path",
+                        "description": "Group trigger definition id to be retrieved.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "dampeningId",
+                        "in": "path",
+                        "description": "Updated dampening definition.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Updated dampening definition.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Dampening"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success, Dampening Updated.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Dampening"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No Dampening Found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete an existing group dampening definition.",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "groupId",
+                        "in": "path",
+                        "description": "Group Trigger definition id to be deleted.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "dampeningId",
+                        "in": "path",
+                        "description": "Dampening id for dampening definition to be deleted.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success, Dampening updated.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FullTrigger"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/{triggerId}/dampenings": {
+            "get": {
+                "summary": "Get all Dampenings for a Trigger (1 Dampening per mode).",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "triggerId",
+                        "in": "path",
+                        "description": "Trigger definition id to be retrieved.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success, Trigger found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Dampening"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "summary": "Create a new dampening.",
+                "description": "Return Dampening created.",
+                "parameters": [
+                    {
+                        "name": "triggerId",
+                        "in": "path",
+                        "description": "Trigger definition id attached to dampening.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Dampening definition to be created.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Dampening"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success, Dampening created.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Dampening"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/{triggerId}/conditions": {
+            "put": {
+                "summary": "Set the conditions for the trigger. ",
+                "description": "This sets the conditions for all trigger modes, replacing existing conditions for all trigger modes. Returns the new conditions.",
+                "parameters": [
+                    {
+                        "name": "triggerId",
+                        "in": "path",
+                        "description": "The relevant Trigger.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Collection of Conditions to set.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Condition"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success, Condition Set created.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Condition"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Trigger not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "summary": "Get all conditions for a specific trigger.",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "triggerId",
+                        "in": "path",
+                        "description": "Trigger definition id to be retrieved.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully fetched list of conditions.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Condition"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/{triggerId}/conditions/{triggerMode}": {
+            "put": {
+                "summary": "Set the conditions for the trigger. ",
+                "description": "This sets the conditions for the trigger. This replaces any existing conditions. Returns the new conditions.",
+                "parameters": [
+                    {
+                        "name": "triggerId",
+                        "in": "path",
+                        "description": "The relevant Trigger.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "triggerMode",
+                        "in": "path",
+                        "description": "The trigger mode.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Collection of Conditions to set.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Condition"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success, Condition Set created.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Condition"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Trigger not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/groups/{groupId}/conditions": {
+            "put": {
+                "summary": "Set the conditions for the group trigger. ",
+                "description": "This replaces any existing conditions on the group and member conditions for all trigger modes. + \nReturn the new group conditions.",
+                "parameters": [
+                    {
+                        "name": "groupId",
+                        "in": "path",
+                        "description": "The relevant Group definition id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Collection of Conditions to set and Map with tokens per dataId on members.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/GroupConditionsInfo"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success, Group Condition Set created.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Condition"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Trigger not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/groups/{groupId}/dampenings": {
+            "post": {
+                "summary": "Create a new group dampening.",
+                "description": "Return group Dampening created.",
+                "parameters": [
+                    {
+                        "name": "groupId",
+                        "in": "path",
+                        "description": "Group Trigger definition id attached to dampening.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Dampening definition to be created.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Dampening"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success, Dampening created.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Dampening"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/groups/members": {
+            "post": {
+                "summary": "Create a new member trigger for a parent trigger.",
+                "description": "Returns Member Trigger created if operation finished correctly.",
+                "parameters": [
+                    
+                ],
+                "requestBody": {
+                    "description": "Group member trigger to be created.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/GroupMemberInfo"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success, Member Trigger Created.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Trigger"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Group trigger not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers": {
+            "post": {
+                "summary": "Create a new trigger.",
+                "description": "Returns created trigger.",
+                "parameters": [
+                    
+                ],
+                "requestBody": {
+                    "description": "Trigger definition to be created.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Trigger"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success, Trigger Created.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Trigger"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "summary": "Get triggers with optional filtering.",
+                "description": "If not criteria defined, it fetches all triggers stored in the system.",
+                "parameters": [
+                    {
+                        "name": "triggerIds",
+                        "in": "query",
+                        "description": "Filter out triggers for unspecified triggerIds.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Filter out triggers for unspecified tags.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "thin",
+                        "in": "query",
+                        "description": "Return only thin triggers. Currently Ignored.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully fetched list of triggers.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Trigger"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Trigger not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/groups": {
+            "post": {
+                "summary": "Create a new group trigger.",
+                "description": "Returns created group trigger.",
+                "parameters": [
+                    
+                ],
+                "requestBody": {
+                    "description": "Group member trigger to be created.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Trigger"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success, Group Trigger Created.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Trigger"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/groups/{groupId}/members": {
+            "get": {
+                "summary": "Find all group member trigger definitions.",
+                "description": "No pagination.",
+                "parameters": [
+                    {
+                        "name": "groupId",
+                        "in": "path",
+                        "description": "Group Trigger definition id.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "includeOrphans",
+                        "in": "query",
+                        "description": "include Orphan members? No if omitted.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully fetched list of triggers.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Trigger"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Trigger not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/{triggerId}/dampenings/mode/{triggerMode}": {
+            "get": {
+                "summary": "Get dampening using triggerId and triggerMode.",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "triggerId",
+                        "in": "path",
+                        "description": "Trigger definition id to be retrieved.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "triggerMode",
+                        "in": "path",
+                        "description": "Trigger mode.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success, Trigger found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Dampening"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/groups/{groupId}/conditions/{triggerMode}": {
+            "put": {
+                "summary": "Set the conditions for the group trigger. ",
+                "description": "This replaces any existing conditions on the group and member conditions. Return the new group conditions.",
+                "parameters": [
+                    {
+                        "name": "groupId",
+                        "in": "path",
+                        "description": "The relevant Group definition id.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "triggerMode",
+                        "in": "path",
+                        "description": "FIRING or AUTORESOLVE (not case sensitive)",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Collection of Conditions to set and Map with tokens per dataId on members.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/GroupConditionsInfo"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success, Group Condition Set created.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Condition"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Trigger not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/enabled": {
+            "put": {
+                "summary": "Update triggers to be enabled or disabled.",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "triggerIds",
+                        "in": "query",
+                        "description": "List of trigger ids to enable or disable",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "enabled",
+                        "in": "query",
+                        "description": "Set enabled or disabled.",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success, Triggers updated."
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Trigger not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/{triggerId}/enable": {
+            "put": {
+                "summary": "Enable trigger.",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "triggerId",
+                        "in": "path",
+                        "description": "Trigger definition id to be enabled.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success, Trigger enabled."
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Trigger not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Disable trigger,",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "triggerId",
+                        "in": "path",
+                        "description": "Trigger definition id to be disabled.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success, Trigger disabled."
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Trigger not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/triggers/groups/enabled": {
+            "put": {
+                "summary": "Update group triggers and their member triggers to be enabled or disabled.",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "triggerIds",
+                        "in": "query",
+                        "description": "List of group trigger ids to enable or disable",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "enabled",
+                        "in": "query",
+                        "description": "Set enabled or disabled.",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success, Group Triggers updated."
+                    },
+                    "400": {
+                        "description": "Bad Request/Invalid Parameters.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Group Trigger not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {
         "schemas": {
-            "GroupConditionsInfo": {
-                "description": "A convenience class used in the REST API to POST a new Group Condition. + \n + \nA group-level condition uses dataId tokens for the dataIds defined in the condition.  + \nThe group members must then replace the tokens with actual dataIds. + \n + \nFor example, we may define a group ThresholdCondition like ( $SystemLoad$ > 80 ). + \nEach member must then replace $SystemLoad$ with the actual system load dataId for that member. + \n + \nThe dataIdMemberMap is a map of the dataId tokens in the group conditions to the actual dataIds + \nused for the current member triggers. + \nBecause most condition types have only one dataId the map will typically have 1 entry per condition. + \nBut because a condition could have multiple dataIds (e.g CompareCondition has dataId and data2Id), + \nit may have more entries than conditions. + \nThe inner map maps member triggerIds to the dataId to be used for that member trigger for the given token. + \nIt should have 1 entry for each member trigger. + \n + \nFor example, let's define a group trigger with two conditions: + \n + \nThresholdCondition( $SystemLoad$ > 80 ) + \nThresholdCondition( $HeapUsed$ > 70 ) + \n + \nIf the group has two current members, with triggerId's Member1 and Member2, + \nthe map would look like this: + \n + \n{ + \n\"$SystemLoad$\":{\"Member1\":\"Member1SystemLoad\", \"Member2\":\"Member2SystemLoad\"}, + \n\"$HeapUsed$\":{\"Member1\":\"Member1HeapUsed\", \"Member2\":\"Member2HeapUsed\"} + \n} + \n + \nSo, in the example the actual $SystemLoad$ dataIds would be Member1SystemLoad and Member2SystemLoad. + \nWith this Map we can now add the group-level conditions and also the two member-level conditions + \nto each member + \n + \nA NOTE ABOUT EXTERNAL CONDITIONS. <code>ExternalCondition.expression</code> will automatically have the + \nsame token replacement performed. So, all occurrences of the dataId token found in the expression, + \nwill be replaced with the mapping. This allows the expression of a group external condition to be + \nautomatically customized to the member.",
-                "properties": {
-                    "conditions": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Condition"
-                        },
-                        "description": "A list of conditions for a Group Trigger."
-                    },
-                    "dataIdMemberMap": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "string"
-                        },
-                        "description": "A map of the dataId tokens in the group conditions to the actual dataIds used for the current member triggers. Can be empty if the group has no existing members."
-                    }
-                }
-            },
-            "FullTrigger": {
-                "description": "Representation of a <<Trigger>> with <<Dampening>> and <<Condition>> objects.",
-                "properties": {
-                    "trigger": {
-                        "$ref": "#/components/schemas/Trigger",
-                        "description": "The trigger."
-                    },
-                    "dampenings": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Dampening"
-                        },
-                        "description": "A list of dampenings linked with the trigger."
-                    },
-                    "conditions": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Condition"
-                        },
-                        "description": "A list of conditions linked with the trigger."
-                    }
-                }
-            },
-            "ApiDeleted": {
-                "description": "Payload for a simple REST deleted number response.",
-                "properties": {
-                    "deleted": {
-                        "type": "integer",
-                        "format": "int32",
-                        "description": "Deleted items."
-                    }
-                }
-            },
-            "Dampening": {
-                "description": "A representation of dampening status. + \n + \nIt\u2019s often the case that you don\u2019t want a trigger to fire every time a condition set is met. + \nInstead, you want to ensure that the issue is not a spike of activity. + \nHawkular Alerting provides several ways of ensuring triggers fire only as desired. + \n + \nThis is a Trigger Dampening in Hawkular Alerting terminology. + \n + \nDampening types: + \n + \nSTRICT + \n + \n- N consecutive true evaluations. + \n- Useful for ignoring spikes in activity or waiting for a prolonged event. + \n + \nRELAXED_COUNT + \n + \n- N true evaluations out of M total evaluations. + \n- Useful for ignoring short spikes in activity but catching frequently spiking activity. + \n + \nRELAXED_TIME + \n + \n- N true evaluations in T time. + \n- Useful for ignoring short spikes in activity but catching frequently spiking activity. \n + \nSTRICT_TIME + \n + \n- Only true evaluations for at least T time. + \n- Useful for reporting a continued aberration. + \n + \nSTRICT_TIMEOUT + \n + \n- Only true evaluations for T time. + \n- Useful for reporting a continued aberration with a more guaranteed firing time. + \n",
-                "properties": {
-                    "tenantId": {
-                        "type": "string",
-                        "description": "Tenant id owner of this dampening."
-                    },
-                    "triggerId": {
-                        "type": "string",
-                        "description": "The owning trigger."
-                    },
-                    "triggerMode": {
-                        "type": "string",
-                        "enum": [
-                            "FIRING",
-                            "AUTORESOLVE"
-                        ],
-                        "description": "The owning trigger's mode when this dampening is active."
-                    },
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "STRICT",
-                            "RELAXED_COUNT",
-                            "RELAXED_TIME",
-                            "STRICT_TIME",
-                            "STRICT_TIMEOUT"
-                        ],
-                        "description": "The type of the dampening."
-                    },
-                    "evalTrueSetting": {
-                        "type": "integer",
-                        "format": "int32",
-                        "description": "Number of required true evaluations for STRICT, RELAXED_COUNT, RELAXED_TIME"
-                    },
-                    "evalTotalSetting": {
-                        "type": "integer",
-                        "format": "int32",
-                        "description": "Number of allowed evaluation attempts for RELAXED_COUNT"
-                    },
-                    "evalTimeSetting": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Time period in milliseconds for RELAXED_TIME, STRICT_TIME, STRICT_TIMEOUT"
-                    },
-                    "dampeningId": {
-                        "type": "string",
-                        "description": "A composed key for the dampening. This is a read-only value defined by the system."
-                    }
-                }
-            },
             "Event": {
                 "description": "An Alert is an Event. + \n + \nFor the most part an Event can be thought of as an Alert without life-cycle. + \n + \nAlerts are always generated by a Trigger. + \n + \nEvents may be generated by a Trigger or may be created directly via the API. + \n",
                 "properties": {
@@ -4563,29 +4469,25 @@
                     }
                 }
             },
-            "ApiError": {
-                "description": "Payload for a REST error response.",
+            "Action": {
+                "description": "An action represents a consequence of an event. + \n + \nAn Action object represents a particular action linked with a specific event. + \nAction objects are generated by the Alerting engine and processed by plugins. + \nAn Action object stores the eventId property and optionally may contain the full Event object. + \nAn Action may store the result of the processing by a plugin. + \n",
                 "properties": {
-                    "errorMsg": {
+                    "eventId": {
                         "type": "string",
-                        "description": "The error message."
-                    }
-                }
-            },
-            "UnorphanMemberInfo": {
-                "description": "A convenience class used in the REST API to un-orphan an orphan group Member Trigger. + \n + \nA group-level condition uses dataId tokens for the dataIds defined in the condition. + \nThe group members must then replace the tokens with actual dataIds. + \n + \nFor example, we may define a group ThresholdCondition like ( $SystemLoad$ > 80 ). + \nEach member must then replace $SystemLoad$ with the actual system load dataId for that member. + \nThe dataIdMap is a map of the dataId tokens in the group conditions to the actual dataIds to + \nbe used for the member being added. For example, assume the group trigger has two conditions defined: + \n + \nThresholdCondition( $SystemLoad$ > 80 ) and ThresholdCondition( $HeapUsed$ > 70 ) + \n + \nAnd now let's assume we are adding a new member, Member1.  The map would look like this: + \n + \n{ \"$SystemLoad$\":\"Member1SystemLoad\", \"$HeapUsed$\":\"Member1HeapUsed\" } + \n + \nSo, in the example the actual dataIds would be Member1SystemLoad and Member1HeapUsed. + \nWith this Map we can now add the new member trigger. + \n + \nA NOTE ABOUT EXTERNAL CONDITIONS. ExternalCondition.expression will automatically have the + \nsame token replacement performed. So, all occurrences of the dataId token found in the expression, + \nwill be replaced with the mapping. + \nThis allows the expression of a group external condition to be automatically customized to the member.",
-                "properties": {
-                    "memberContext": {
-                        "type": "object",
-                        "description": "Trigger context for member Trigger."
+                        "description": "Event id from where this action is generated."
                     },
-                    "memberTags": {
-                        "type": "object",
-                        "description": "Trigger tags for member Trigger."
+                    "ctime": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Time when this action was generated."
                     },
-                    "dataIdMap": {
-                        "type": "object",
-                        "description": "A map of the dataId tokens in the group conditions to the actual dataIds to be used for the member being added. + \nCan be empty if the group has no current conditions."
+                    "event": {
+                        "$ref": "#/components/schemas/Event",
+                        "description": "Attached Event from where this action is generated."
+                    },
+                    "result": {
+                        "type": "string",
+                        "description": "Result of action processing."
                     }
                 }
             },
@@ -4619,6 +4521,49 @@
                     "dataIdMap": {
                         "type": "object",
                         "description": "A map of the dataId tokens in the group conditions to the actual dataIds to be used for the member being added. + \nCan be empty if the group has no current conditions."
+                    }
+                }
+            },
+            "UnorphanMemberInfo": {
+                "description": "A convenience class used in the REST API to un-orphan an orphan group Member Trigger. + \n + \nA group-level condition uses dataId tokens for the dataIds defined in the condition. + \nThe group members must then replace the tokens with actual dataIds. + \n + \nFor example, we may define a group ThresholdCondition like ( $SystemLoad$ > 80 ). + \nEach member must then replace $SystemLoad$ with the actual system load dataId for that member. + \nThe dataIdMap is a map of the dataId tokens in the group conditions to the actual dataIds to + \nbe used for the member being added. For example, assume the group trigger has two conditions defined: + \n + \nThresholdCondition( $SystemLoad$ > 80 ) and ThresholdCondition( $HeapUsed$ > 70 ) + \n + \nAnd now let's assume we are adding a new member, Member1.  The map would look like this: + \n + \n{ \"$SystemLoad$\":\"Member1SystemLoad\", \"$HeapUsed$\":\"Member1HeapUsed\" } + \n + \nSo, in the example the actual dataIds would be Member1SystemLoad and Member1HeapUsed. + \nWith this Map we can now add the new member trigger. + \n + \nA NOTE ABOUT EXTERNAL CONDITIONS. ExternalCondition.expression will automatically have the + \nsame token replacement performed. So, all occurrences of the dataId token found in the expression, + \nwill be replaced with the mapping. + \nThis allows the expression of a group external condition to be automatically customized to the member.",
+                "properties": {
+                    "memberContext": {
+                        "type": "object",
+                        "description": "Trigger context for member Trigger."
+                    },
+                    "memberTags": {
+                        "type": "object",
+                        "description": "Trigger tags for member Trigger."
+                    },
+                    "dataIdMap": {
+                        "type": "object",
+                        "description": "A map of the dataId tokens in the group conditions to the actual dataIds to be used for the member being added. + \nCan be empty if the group has no current conditions."
+                    }
+                }
+            },
+            "Definitions": {
+                "description": "Representation of a list of full triggers (trigger, dampenings and conditions),group members triggers and actions definitions. + \nUsed for bulk import/export operations.",
+                "properties": {
+                    "triggers": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/FullTrigger"
+                        },
+                        "description": "List of full triggers."
+                    },
+                    "groupMembersInfo": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/GroupMemberInfo"
+                        },
+                        "description": "List of group member triggers information."
+                    },
+                    "actions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ActionDefinition"
+                        },
+                        "description": "List of action definitions."
                     }
                 }
             },
@@ -4755,6 +4700,61 @@
                     }
                 }
             },
+            "ApiError": {
+                "description": "Payload for a REST error response.",
+                "properties": {
+                    "errorMsg": {
+                        "type": "string",
+                        "description": "The error message."
+                    }
+                }
+            },
+            "Alert": {
+                "description": "Alerts are generated when an Alert Trigger fires, based on a set of defined conditions + \nthat have been matched, possibly more than once or have held true over a period of time. + \n + \nWhen fired the trigger can perform actions based on plugins (e-mail, sms, etc). + \n + \nAlerts then start moving through the Open, Acknowledged, Resolved life-cycle. + \n + \n- Open status represents an alert which has not been seen/taken yet by any user. + \n- Acknowledge status represents an alert which has been seen/taken by any user and it is pending resolution. + \n- Resolved status represents an alert which problem has been resolved. + \n + \nAlerts can be resolved automatically using AUTORESOLVE <<Trigger>> conditions or manually via API. + \n + \nAlert can attach a list of notes defined by the user. + \n + \nThere are many options on triggers to help ensure that alerts are not generated too frequently, + \nincluding ways of automatically disabling and enabling the trigger. + \n",
+                "properties": {
+                    "severity": {
+                        "type": "string",
+                        "enum": [
+                            "LOW",
+                            "MEDIUM",
+                            "HIGH",
+                            "CRITICAL"
+                        ],
+                        "description": "Severity set for a <<Trigger>> and assigned to an alert when it is generated.",
+                        "default": "MEDIUM"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "OPEN",
+                            "ACKNOWLEDGED",
+                            "RESOLVED"
+                        ],
+                        "description": "Lifecycle current status."
+                    },
+                    "notes": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Note"
+                        },
+                        "description": "Notes attached with this alert."
+                    },
+                    "lifecycle": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/LifeCycle"
+                        },
+                        "description": "List of lifecycle states that this alert has navigated."
+                    },
+                    "resolvedEvalSets": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ConditionEval"
+                        },
+                        "description": "The Eval Sets that resolved the <<Trigger>> in AUTORESOLVE mode. + \n Null for non AUTORESOLVE triggers."
+                    }
+                }
+            },
             "ActionDefinition": {
                 "description": "An action represents a consequence of an event. + \n + \nActions are processed by plugins, and plugins offer a map of properties to personalize an action. + \nAn ActionDefinition stores which properties will be used for a specific action in a specific plugin. + \n + \nA Trigger definition can be assigned a list of action definitions. + \n + \nThe alert engine will instantiate a specific Action based on its ActionDefinition. + \n + \nAn ActionDefinition can add default constraints to determine when an action will be performed. + \n + \n<<TriggerAction>> can override the default constraints. + \n-- States constraint: a set of Alert.Status (represented by its string value). + \nThe action is limited to the specified states.  By default the action applies to all Alert states. + \nUnlike Alerts, Events don't have lifecycle. All TriggerActions are applied at Event creation time. + \n + \n-- Calendar constraint: A <<TimeConstraint>>. + \nThe action is applied only when the event create time occurs during the specified time intervals, + \nabsolute or relative, as defined. By default the action can be performed at any time. + \n + \nIf a <<TriggerAction>> defines any constraints the <<ActionDefinition>> constraints will be ignored. + \nIf a <<TriggerAction>> defines no constraints the <<ActionDefinition>> constraints will be used. + \n",
                 "properties": {
@@ -4791,25 +4791,26 @@
                     }
                 }
             },
-            "Action": {
-                "description": "An action represents a consequence of an event. + \n + \nAn Action object represents a particular action linked with a specific event. + \nAction objects are generated by the Alerting engine and processed by plugins. + \nAn Action object stores the eventId property and optionally may contain the full Event object. + \nAn Action may store the result of the processing by a plugin. + \n",
+            "FullTrigger": {
+                "description": "Representation of a <<Trigger>> with <<Dampening>> and <<Condition>> objects.",
                 "properties": {
-                    "eventId": {
-                        "type": "string",
-                        "description": "Event id from where this action is generated."
+                    "trigger": {
+                        "$ref": "#/components/schemas/Trigger",
+                        "description": "The trigger."
                     },
-                    "ctime": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Time when this action was generated."
+                    "dampenings": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Dampening"
+                        },
+                        "description": "A list of dampenings linked with the trigger."
                     },
-                    "event": {
-                        "$ref": "#/components/schemas/Event",
-                        "description": "Attached Event from where this action is generated."
-                    },
-                    "result": {
-                        "type": "string",
-                        "description": "Result of action processing."
+                    "conditions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Condition"
+                        },
+                        "description": "A list of conditions linked with the trigger."
                     }
                 }
             },
@@ -4877,6 +4878,57 @@
                     }
                 }
             },
+            "Dampening": {
+                "description": "A representation of dampening status. + \n + \nIt\u2019s often the case that you don\u2019t want a trigger to fire every time a condition set is met. + \nInstead, you want to ensure that the issue is not a spike of activity. + \nHawkular Alerting provides several ways of ensuring triggers fire only as desired. + \n + \nThis is a Trigger Dampening in Hawkular Alerting terminology. + \n + \nDampening types: + \n + \nSTRICT + \n + \n- N consecutive true evaluations. + \n- Useful for ignoring spikes in activity or waiting for a prolonged event. + \n + \nRELAXED_COUNT + \n + \n- N true evaluations out of M total evaluations. + \n- Useful for ignoring short spikes in activity but catching frequently spiking activity. + \n + \nRELAXED_TIME + \n + \n- N true evaluations in T time. + \n- Useful for ignoring short spikes in activity but catching frequently spiking activity. \n + \nSTRICT_TIME + \n + \n- Only true evaluations for at least T time. + \n- Useful for reporting a continued aberration. + \n + \nSTRICT_TIMEOUT + \n + \n- Only true evaluations for T time. + \n- Useful for reporting a continued aberration with a more guaranteed firing time. + \n",
+                "properties": {
+                    "tenantId": {
+                        "type": "string",
+                        "description": "Tenant id owner of this dampening."
+                    },
+                    "triggerId": {
+                        "type": "string",
+                        "description": "The owning trigger."
+                    },
+                    "triggerMode": {
+                        "type": "string",
+                        "enum": [
+                            "FIRING",
+                            "AUTORESOLVE"
+                        ],
+                        "description": "The owning trigger's mode when this dampening is active."
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "STRICT",
+                            "RELAXED_COUNT",
+                            "RELAXED_TIME",
+                            "STRICT_TIME",
+                            "STRICT_TIMEOUT"
+                        ],
+                        "description": "The type of the dampening."
+                    },
+                    "evalTrueSetting": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Number of required true evaluations for STRICT, RELAXED_COUNT, RELAXED_TIME"
+                    },
+                    "evalTotalSetting": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Number of allowed evaluation attempts for RELAXED_COUNT"
+                    },
+                    "evalTimeSetting": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Time period in milliseconds for RELAXED_TIME, STRICT_TIME, STRICT_TIMEOUT"
+                    },
+                    "dampeningId": {
+                        "type": "string",
+                        "description": "A composed key for the dampening. This is a read-only value defined by the system."
+                    }
+                }
+            },
             "Data": {
                 "description": "A base class for incoming data into alerts subsystem. + \nAll Data has TenantId, Id and a timestamp. + \nAn Id should be unique within the tenant. + \nThe timestamp is used to ensure that data is time-ordered when being sent into the alerting engine. + \nIf not assigned the timestamp will be assigned to current time.",
                 "properties": {
@@ -4908,20 +4960,97 @@
                     }
                 }
             },
-            "Alert": {
-                "description": "Alerts are generated when an Alert Trigger fires, based on a set of defined conditions + \nthat have been matched, possibly more than once or have held true over a period of time. + \n + \nWhen fired the trigger can perform actions based on plugins (e-mail, sms, etc). + \n + \nAlerts then start moving through the Open, Acknowledged, Resolved life-cycle. + \n + \n- Open status represents an alert which has not been seen/taken yet by any user. + \n- Acknowledge status represents an alert which has been seen/taken by any user and it is pending resolution. + \n- Resolved status represents an alert which problem has been resolved. + \n + \nAlerts can be resolved automatically using AUTORESOLVE <<Trigger>> conditions or manually via API. + \n + \nAlert can attach a list of notes defined by the user. + \n + \nThere are many options on triggers to help ensure that alerts are not generated too frequently, + \nincluding ways of automatically disabling and enabling the trigger. + \n",
+            "GroupConditionsInfo": {
+                "description": "A convenience class used in the REST API to POST a new Group Condition. + \n + \nA group-level condition uses dataId tokens for the dataIds defined in the condition.  + \nThe group members must then replace the tokens with actual dataIds. + \n + \nFor example, we may define a group ThresholdCondition like ( $SystemLoad$ > 80 ). + \nEach member must then replace $SystemLoad$ with the actual system load dataId for that member. + \n + \nThe dataIdMemberMap is a map of the dataId tokens in the group conditions to the actual dataIds + \nused for the current member triggers. + \nBecause most condition types have only one dataId the map will typically have 1 entry per condition. + \nBut because a condition could have multiple dataIds (e.g CompareCondition has dataId and data2Id), + \nit may have more entries than conditions. + \nThe inner map maps member triggerIds to the dataId to be used for that member trigger for the given token. + \nIt should have 1 entry for each member trigger. + \n + \nFor example, let's define a group trigger with two conditions: + \n + \nThresholdCondition( $SystemLoad$ > 80 ) + \nThresholdCondition( $HeapUsed$ > 70 ) + \n + \nIf the group has two current members, with triggerId's Member1 and Member2, + \nthe map would look like this: + \n + \n{ + \n\"$SystemLoad$\":{\"Member1\":\"Member1SystemLoad\", \"Member2\":\"Member2SystemLoad\"}, + \n\"$HeapUsed$\":{\"Member1\":\"Member1HeapUsed\", \"Member2\":\"Member2HeapUsed\"} + \n} + \n + \nSo, in the example the actual $SystemLoad$ dataIds would be Member1SystemLoad and Member2SystemLoad. + \nWith this Map we can now add the group-level conditions and also the two member-level conditions + \nto each member + \n + \nA NOTE ABOUT EXTERNAL CONDITIONS. <code>ExternalCondition.expression</code> will automatically have the + \nsame token replacement performed. So, all occurrences of the dataId token found in the expression, + \nwill be replaced with the mapping. This allows the expression of a group external condition to be + \nautomatically customized to the member.",
                 "properties": {
-                    "severity": {
+                    "conditions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Condition"
+                        },
+                        "description": "A list of conditions for a Group Trigger."
+                    },
+                    "dataIdMemberMap": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "A map of the dataId tokens in the group conditions to the actual dataIds used for the current member triggers. Can be empty if the group has no existing members."
+                    }
+                }
+            },
+            "ApiDeleted": {
+                "description": "Payload for a simple REST deleted number response.",
+                "properties": {
+                    "deleted": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Deleted items."
+                    }
+                }
+            },
+            "ExternalCondition": {
+                "description": "An ExternalCondition is used for condition evaluations performed outside of the Alerting engine. + \n + \nThe external engine will send StringData providing the data for which the external evaluation  + \nhas already evaluated to true. + \n + \nThe Alerting engine assumes a true evaluation for the data being sent in from the external engine. In other words, every <<ExternalConditionEval>> will have a true evaluation and therefore, for triggers with only a single external condition, and with default dampening, an alert will be fired for each data submission.",
+                "properties": {
+                    "alerterId": {
+                        "type": "string",
+                        "description": "An identifier assigned by the external alerter to identify this condition as being handled by that. It should be unique enough such that external AlerterIds are unique."
+                    },
+                    "expression": {
+                        "type": "string",
+                        "description": "The operator/pattern/expression/description of the external condition. The use of this field is up to the external engine, It may be a pattern, expression or operator used to configure/drive an external evaluation engine or may just be a static description of the externally defined event."
+                    }
+                }
+            },
+            "ThresholdCondition": {
+                "description": "A numeric threshold condition.",
+                "properties": {
+                    "operator": {
                         "type": "string",
                         "enum": [
-                            "LOW",
-                            "MEDIUM",
-                            "HIGH",
-                            "CRITICAL"
+                            "LT",
+                            "GT",
+                            "LTE",
+                            "GTE"
                         ],
-                        "description": "Severity set for a <<Trigger>> and assigned to an alert when it is generated.",
-                        "default": "MEDIUM"
+                        "description": "Compare operator [LT (<), GT (>), LTE (<=), GTE (>=)]."
                     },
+                    "threshold": {
+                        "type": "number",
+                        "format": "double",
+                        "description": "Condition threshold."
+                    }
+                }
+            },
+            "StringCondition": {
+                "description": "A string comparison condition.",
+                "properties": {
+                    "operator": {
+                        "type": "string",
+                        "enum": [
+                            "EQUAL",
+                            "NOT_EQUAL",
+                            "STARTS_WITH",
+                            "ENDS_WITH",
+                            "CONTAINS",
+                            "MATCH"
+                        ],
+                        "description": "String operator."
+                    },
+                    "pattern": {
+                        "type": "string",
+                        "description": "Pattern to be used with the string operator."
+                    },
+                    "ignoreCase": {
+                        "type": "boolean",
+                        "description": "Flag to indicate whether pattern should ignore case in the string operator expression.",
+                        "default": "false"
+                    }
+                }
+            },
+            "LifeCycle": {
+                "description": "A lifecycle state representation.",
+                "properties": {
                     "status": {
                         "type": "string",
                         "enum": [
@@ -4929,54 +5058,67 @@
                             "ACKNOWLEDGED",
                             "RESOLVED"
                         ],
-                        "description": "Lifecycle current status."
+                        "description": "The status of this lifecycle.",
+                        "default": "OPEN"
                     },
-                    "notes": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Note"
-                        },
-                        "description": "Notes attached with this alert."
+                    "user": {
+                        "type": "string",
+                        "description": "The user who creates the state + \nOpen statutes are created by 'system' + \nIn AUTORESOLVE triggers Resolved statutes are create by 'AutoResolve'."
                     },
-                    "lifecycle": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/LifeCycle"
-                        },
-                        "description": "List of lifecycle states that this alert has navigated."
-                    },
-                    "resolvedEvalSets": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ConditionEval"
-                        },
-                        "description": "The Eval Sets that resolved the <<Trigger>> in AUTORESOLVE mode. + \n Null for non AUTORESOLVE triggers."
+                    "stime": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Creation time for this state."
                     }
                 }
             },
-            "Definitions": {
-                "description": "Representation of a list of full triggers (trigger, dampenings and conditions),group members triggers and actions definitions. + \nUsed for bulk import/export operations.",
+            "Note": {
+                "description": "A simple note representation.",
                 "properties": {
-                    "triggers": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/FullTrigger"
-                        },
-                        "description": "List of full triggers."
+                    "user": {
+                        "type": "string",
+                        "description": "The user who creates the note."
                     },
-                    "groupMembersInfo": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/GroupMemberInfo"
-                        },
-                        "description": "List of group member triggers information."
+                    "ctime": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Note creation time."
                     },
-                    "actions": {
+                    "text": {
+                        "type": "string",
+                        "description": "The note text."
+                    }
+                }
+            },
+            "TriggerAction": {
+                "description": "Links an <<ActionDefinition>> with a <<Trigger>>.\n\nThe TriggerAction can override the constraints set on the <<ActionDefintion>>.\nIf a <<TriggerAction>> defines any constraints the <<ActionDefinition>> constraints will be ignored.\nIf a <<TriggerAction>> defines no constraints the <<ActionDefinition>> constraints will be used.\nIf a <<TriggerAction>> defines properties and no actionId, the <<ActionDefinition>> will be created.\n",
+                "properties": {
+                    "tenantId": {
+                        "type": "string",
+                        "description": "Tenant id owner of this trigger."
+                    },
+                    "actionPlugin": {
+                        "type": "string",
+                        "description": "Action plugin identifier."
+                    },
+                    "actionId": {
+                        "type": "string",
+                        "description": "Action definition identifier."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "description": "Plugin properties. Each plugin defines its own specific properties that can be supplied at action definition level. If properties is given, actionId must be empty as it is generated."
+                    },
+                    "states": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/ActionDefinition"
+                            "type": "string"
                         },
-                        "description": "List of action definitions."
+                        "description": "A list of Alert.Status restricting active states for this action."
+                    },
+                    "calendar": {
+                        "$ref": "#/components/schemas/TimeConstraint",
+                        "description": "A TimeConstraint restricting active times for this action."
                     }
                 }
             },
@@ -5007,60 +5149,17 @@
                     }
                 }
             },
-            "CompareCondition": {
-                "description": "A numeric comparison condition. + \n + \nExamples: + \nX > 80% of Y, FreeSpace < 20% of TotalSpace + \n",
+            "AvailabilityCondition": {
+                "description": "An availability condition definition. + \n + \nExamples: + \nX is DOWN",
                 "properties": {
                     "operator": {
                         "type": "string",
                         "enum": [
-                            "LT",
-                            "GT",
-                            "LTE",
-                            "GTE"
+                            "DOWN",
+                            "NOT_UP",
+                            "UP"
                         ],
-                        "description": "Compare operator [LT (<), GT (>), LTE (<=), GTE (>=)]."
-                    },
-                    "data2Id": {
-                        "type": "string",
-                        "description": "Data identifier of the metric used for comparison."
-                    },
-                    "data2Multiplier": {
-                        "type": "number",
-                        "format": "double",
-                        "description": "Straight multiplier to be applied to data2Id on the comparison. Final comparison expression can be read as \"dataId <operator> data2Multiplier*data2Id\"."
-                    }
-                }
-            },
-            "EventCondition": {
-                "description": "An EventCondition is used for condition evaluations over Event data using expressions.\n",
-                "properties": {
-                    "expression": {
-                        "type": "string",
-                        "description": "Event expression used for this condition."
-                    }
-                }
-            },
-            "LifeCycle": {
-                "description": "A lifecycle state representation.",
-                "properties": {
-                    "status": {
-                        "type": "string",
-                        "enum": [
-                            "OPEN",
-                            "ACKNOWLEDGED",
-                            "RESOLVED"
-                        ],
-                        "description": "The status of this lifecycle.",
-                        "default": "OPEN"
-                    },
-                    "user": {
-                        "type": "string",
-                        "description": "The user who creates the state + \nOpen statutes are created by 'system' + \nIn AUTORESOLVE triggers Resolved statutes are create by 'AutoResolve'."
-                    },
-                    "stime": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Creation time for this state."
+                        "description": "Availability operator."
                     }
                 }
             },
@@ -5087,50 +5186,6 @@
                         ],
                         "description": "Time period used for the evaluation."
                     },
-                    "operator": {
-                        "type": "string",
-                        "enum": [
-                            "LT",
-                            "GT",
-                            "LTE",
-                            "GTE"
-                        ],
-                        "description": "Compare operator [LT (<), GT (>), LTE (<=), GTE (>=)]."
-                    },
-                    "threshold": {
-                        "type": "number",
-                        "format": "double",
-                        "description": "Condition threshold."
-                    }
-                }
-            },
-            "AvailabilityCondition": {
-                "description": "An availability condition definition. + \n + \nExamples: + \nX is DOWN",
-                "properties": {
-                    "operator": {
-                        "type": "string",
-                        "enum": [
-                            "DOWN",
-                            "NOT_UP",
-                            "UP"
-                        ],
-                        "description": "Availability operator."
-                    }
-                }
-            },
-            "MissingCondition": {
-                "description": "A MissingCondition is used to evaluate when a data or an event has not been received on time interval. + \n + \nA MissingCondition will be evaluated to true when a data/event has not been received in the last interval time, in milliseconds, starting to count from trigger was enabled or last received data/event.",
-                "properties": {
-                    "interval": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "A time interval defined in milliseconds."
-                    }
-                }
-            },
-            "ThresholdCondition": {
-                "description": "A numeric threshold condition.",
-                "properties": {
                     "operator": {
                         "type": "string",
                         "enum": [
@@ -5195,92 +5250,27 @@
                     }
                 }
             },
-            "TriggerAction": {
-                "description": "Links an <<ActionDefinition>> with a <<Trigger>>.\n\nThe TriggerAction can override the constraints set on the <<ActionDefintion>>.\nIf a <<TriggerAction>> defines any constraints the <<ActionDefinition>> constraints will be ignored.\nIf a <<TriggerAction>> defines no constraints the <<ActionDefinition>> constraints will be used.\nIf a <<TriggerAction>> defines properties and no actionId, the <<ActionDefinition>> will be created.\n",
-                "properties": {
-                    "tenantId": {
-                        "type": "string",
-                        "description": "Tenant id owner of this trigger."
-                    },
-                    "actionPlugin": {
-                        "type": "string",
-                        "description": "Action plugin identifier."
-                    },
-                    "actionId": {
-                        "type": "string",
-                        "description": "Action definition identifier."
-                    },
-                    "properties": {
-                        "type": "object",
-                        "description": "Plugin properties. Each plugin defines its own specific properties that can be supplied at action definition level. If properties is given, actionId must be empty as it is generated."
-                    },
-                    "states": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "description": "A list of Alert.Status restricting active states for this action."
-                    },
-                    "calendar": {
-                        "$ref": "#/components/schemas/TimeConstraint",
-                        "description": "A TimeConstraint restricting active times for this action."
-                    }
-                }
-            },
-            "ExternalCondition": {
-                "description": "An ExternalCondition is used for condition evaluations performed outside of the Alerting engine. + \n + \nThe external engine will send StringData providing the data for which the external evaluation  + \nhas already evaluated to true. + \n + \nThe Alerting engine assumes a true evaluation for the data being sent in from the external engine. In other words, every <<ExternalConditionEval>> will have a true evaluation and therefore, for triggers with only a single external condition, and with default dampening, an alert will be fired for each data submission.",
-                "properties": {
-                    "alerterId": {
-                        "type": "string",
-                        "description": "An identifier assigned by the external alerter to identify this condition as being handled by that. It should be unique enough such that external AlerterIds are unique."
-                    },
-                    "expression": {
-                        "type": "string",
-                        "description": "The operator/pattern/expression/description of the external condition. The use of this field is up to the external engine, It may be a pattern, expression or operator used to configure/drive an external evaluation engine or may just be a static description of the externally defined event."
-                    }
-                }
-            },
-            "Note": {
-                "description": "A simple note representation.",
-                "properties": {
-                    "user": {
-                        "type": "string",
-                        "description": "The user who creates the note."
-                    },
-                    "ctime": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Note creation time."
-                    },
-                    "text": {
-                        "type": "string",
-                        "description": "The note text."
-                    }
-                }
-            },
-            "StringCondition": {
-                "description": "A string comparison condition.",
+            "CompareCondition": {
+                "description": "A numeric comparison condition. + \n + \nExamples: + \nX > 80% of Y, FreeSpace < 20% of TotalSpace + \n",
                 "properties": {
                     "operator": {
                         "type": "string",
                         "enum": [
-                            "EQUAL",
-                            "NOT_EQUAL",
-                            "STARTS_WITH",
-                            "ENDS_WITH",
-                            "CONTAINS",
-                            "MATCH"
+                            "LT",
+                            "GT",
+                            "LTE",
+                            "GTE"
                         ],
-                        "description": "String operator."
+                        "description": "Compare operator [LT (<), GT (>), LTE (<=), GTE (>=)]."
                     },
-                    "pattern": {
+                    "data2Id": {
                         "type": "string",
-                        "description": "Pattern to be used with the string operator."
+                        "description": "Data identifier of the metric used for comparison."
                     },
-                    "ignoreCase": {
-                        "type": "boolean",
-                        "description": "Flag to indicate whether pattern should ignore case in the string operator expression.",
-                        "default": "false"
+                    "data2Multiplier": {
+                        "type": "number",
+                        "format": "double",
+                        "description": "Straight multiplier to be applied to data2Id on the comparison. Final comparison expression can be read as \"dataId <operator> data2Multiplier*data2Id\"."
                     }
                 }
             },
@@ -5316,6 +5306,111 @@
                     "inRange": {
                         "type": "boolean",
                         "description": "Flag to indicate if condition will match when value is within the range interval or outside the range interval."
+                    }
+                }
+            },
+            "EventCondition": {
+                "description": "An EventCondition is used for condition evaluations over Event data using expressions.\n",
+                "properties": {
+                    "expression": {
+                        "type": "string",
+                        "description": "Event expression used for this condition."
+                    }
+                }
+            },
+            "MissingCondition": {
+                "description": "A MissingCondition is used to evaluate when a data or an event has not been received on time interval. + \n + \nA MissingCondition will be evaluated to true when a data/event has not been received in the last interval time, in milliseconds, starting to count from trigger was enabled or last received data/event.",
+                "properties": {
+                    "interval": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "A time interval defined in milliseconds."
+                    }
+                }
+            },
+            "ThresholdRangeConditionEval": {
+                "description": "An evaluation state for threshold range condition.",
+                "properties": {
+                    "value": {
+                        "type": "number",
+                        "format": "double",
+                        "description": "Numeric value for dataId used in the evaluation."
+                    }
+                }
+            },
+            "CompareConditionEval": {
+                "description": "An evaluation state for compare condition.",
+                "properties": {
+                    "value1": {
+                        "type": "number",
+                        "format": "double",
+                        "description": "Numeric value used for dataId."
+                    },
+                    "value2": {
+                        "type": "number",
+                        "format": "double",
+                        "description": "Numeric value used for data2Id."
+                    },
+                    "context2": {
+                        "type": "object",
+                        "description": "Properties defined by the user at Data level on the data2Id used for this evaluation."
+                    }
+                }
+            },
+            "AvailabilityConditionEval": {
+                "description": "An evaluation state for availability condition.",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "enum": [
+                            "UP",
+                            "DOWN",
+                            "UNAVAILABLE"
+                        ],
+                        "description": "Availability value used for dataId."
+                    }
+                }
+            },
+            "StringConditionEval": {
+                "description": "An evaluation state for string condition.",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "description": "String value for dataId used in the evaluation."
+                    }
+                }
+            },
+            "EventConditionEval": {
+                "description": "An evaluation state for event condition.",
+                "properties": {
+                    "value": {
+                        "$ref": "#/components/schemas/Event",
+                        "description": "Event value used for dataId."
+                    }
+                }
+            },
+            "ThresholdConditionEval": {
+                "description": "An evaluation state for threshold condition.",
+                "properties": {
+                    "value": {
+                        "type": "number",
+                        "format": "double",
+                        "description": "Numeric value for dataId used in the evaluation."
+                    }
+                }
+            },
+            "MissingConditionEval": {
+                "description": "An evaluation state for missing condition.",
+                "properties": {
+                    "previousTime": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Time when trigger was enabled or last time a data/event was received."
+                    },
+                    "time": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Time when most recently evaluation of missing condition."
                     }
                 }
             },
@@ -5359,92 +5454,6 @@
                     "event": {
                         "$ref": "#/components/schemas/Event",
                         "description": "Event value used for dataId."
-                    }
-                }
-            },
-            "ThresholdConditionEval": {
-                "description": "An evaluation state for threshold condition.",
-                "properties": {
-                    "value": {
-                        "type": "number",
-                        "format": "double",
-                        "description": "Numeric value for dataId used in the evaluation."
-                    }
-                }
-            },
-            "AvailabilityConditionEval": {
-                "description": "An evaluation state for availability condition.",
-                "properties": {
-                    "value": {
-                        "type": "string",
-                        "enum": [
-                            "UP",
-                            "DOWN",
-                            "UNAVAILABLE"
-                        ],
-                        "description": "Availability value used for dataId."
-                    }
-                }
-            },
-            "MissingConditionEval": {
-                "description": "An evaluation state for missing condition.",
-                "properties": {
-                    "previousTime": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Time when trigger was enabled or last time a data/event was received."
-                    },
-                    "time": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Time when most recently evaluation of missing condition."
-                    }
-                }
-            },
-            "EventConditionEval": {
-                "description": "An evaluation state for event condition.",
-                "properties": {
-                    "value": {
-                        "$ref": "#/components/schemas/Event",
-                        "description": "Event value used for dataId."
-                    }
-                }
-            },
-            "CompareConditionEval": {
-                "description": "An evaluation state for compare condition.",
-                "properties": {
-                    "value1": {
-                        "type": "number",
-                        "format": "double",
-                        "description": "Numeric value used for dataId."
-                    },
-                    "value2": {
-                        "type": "number",
-                        "format": "double",
-                        "description": "Numeric value used for data2Id."
-                    },
-                    "context2": {
-                        "type": "object",
-                        "description": "Properties defined by the user at Data level on the data2Id used for this evaluation."
-                    }
-                }
-            },
-            "StringConditionEval": {
-                "description": "An evaluation state for string condition.",
-                "properties": {
-                    "value": {
-                        "type": "string",
-                        "description": "String value for dataId used in the evaluation."
-                    }
-                }
-            },
-            "ThresholdRangeConditionEval": {
-                "description": "An evaluation state for threshold range condition.",
-                "properties": {
-                    "value": {
-                        "type": "number",
-                        "format": "double",
-                        "description": "Numeric value for dataId used in the evaluation."
                     }
                 }
             }


### PR DESCRIPTION
Without this, getting the lastTriggered datum may return thousands of entries to the client, just to throw most of them away. Limiting by startTime does not help, as we don't know if the alert had fired before that cut-off-time.

A better implementation would be to narrow down the ISPN query in order to only return the latest alert in the first place.

Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>