### PR TITLE
POL-286 Add the ability to store only thin alerts

### DIFF
--- a/api/src/main/java/org/hawkular/alerts/api/model/event/Event.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/event/Event.java
@@ -265,7 +265,8 @@ public class Event implements Comparable<Event>, Serializable {
 
     public Event(String tenantId, Trigger trigger, Dampening dampening, List<Set<ConditionEval>> evalSets) {
         this.tenantId = tenantId;
-        this.trigger = trigger;
+        this.trigger = new Trigger(trigger);
+        this.trigger.getLifecycle().clear(); // This isn't relevant to event's lifecycle
         this.dampening = dampening;
         this.evalSets = evalSets;
         this.eventType = EventType.EVENT.name();

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnAlertsServiceImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnAlertsServiceImpl.java
@@ -81,9 +81,12 @@ public class IspnAlertsServiceImpl implements AlertsService {
     long eventLifespanInHours;
     long alertsLifespanInHours;
 
+    boolean saveThinAlerts = false;
+
     public void init() {
         alertsLifespanInHours = ConfigProvider.getConfig().getValue("engine.backend.ispn.alerts-lifespan", Long.class);
         eventLifespanInHours = ConfigProvider.getConfig().getValue("engine.backend.ispn.events-lifespan", Long.class);
+        saveThinAlerts = ConfigProvider.getConfig().getValue("engine.backend.ispn.alerts-thin", Boolean.class);
         backend = IspnCacheManager.getCacheManager().getCache("backend");
         if (backend == null) {
             log.error("Ispn backend cache not found. Check configuration.");
@@ -238,6 +241,12 @@ public class IspnAlertsServiceImpl implements AlertsService {
         }
         log.debugf("Adding %s alerts", alerts.size());
         for (Alert alert : alerts) {
+            if(saveThinAlerts) {
+                // This reduces the storage requirements by not storing runtime evaluation information
+                alert.setDampening(null);
+                alert.setEvalSets(null);
+                alert.setResolvedEvalSets(null);
+            }
             store(alert);
         }
     }

--- a/engine/src/test/resources/META-INF/microprofile-config.properties
+++ b/engine/src/test/resources/META-INF/microprofile-config.properties
@@ -7,6 +7,9 @@ engine.backend.ispn.reindex=true
 engine.backend.ispn.alerts-lifespan=1
 engine.backend.ispn.events-lifespan=1
 
+# Store only thin part of the alerts
+engine.backend.ispn.alerts-thin=false
+
 # Used to clean triggers and data cache, defined in milliseconds
 engine.backend.ispn.partition-lifespan=100
 

--- a/external/src/main/resources/application.properties
+++ b/external/src/main/resources/application.properties
@@ -64,6 +64,9 @@ engine.backend.ispn.alerts-lifespan=168
 # Used to clean triggers and data cache, defined in milliseconds
 engine.backend.ispn.partition-lifespan=100
 
+# Store only thin part of the alerts
+engine.backend.ispn.alerts-thin=true
+
 # == Drools properties
 engine.rules.events.duplicate-filter-time=0
 

--- a/external/src/test/resources/application.properties
+++ b/external/src/test/resources/application.properties
@@ -19,6 +19,9 @@ engine.backend.ispn.events-lifespan=1
 # How many hours do we retain the alerts. Set to negative value to store forever
 engine.backend.ispn.alerts-lifespan=1
 
+# Store only thin part of the alerts
+engine.backend.ispn.alerts-thin=false
+
 hawkular.data=hawkular.data
 
 # Used to clean triggers and data cache, defined in milliseconds


### PR DESCRIPTION
Also, when saving an event or alert, do not store the trigger's lifecycle history with it.