### PR TITLE
POL-307 Rename Data id back, as triggers expect the old value.

### DIFF
--- a/external/src/main/resources/application.properties
+++ b/external/src/main/resources/application.properties
@@ -3,6 +3,7 @@
 
 # Logging properties
 quarkus.log.category."com.redhat.cloud.policies.engine".level=${EXTERNAL_LOGGING_LEVEL:INFO}
+quarkus.log.category."org.hawkular.alerts.engine".level=${EXTERNAL_LOGGING_LEVEL:INFO}
 
 # Sentry logging. Off by default, enabled on OpenShift
 # See https://quarkus.io/guides/logging-sentry#in-app-packages


### PR DESCRIPTION
This data id is encoded in stored triggers and provided by the ui-backend when triggers are created.
Changing that value would require data migration in the engine's backend store.