### PR TITLE
POC of returning trigger history items only

### DIFF
--- a/api/src/main/java/org/hawkular/alerts/api/services/AlertsCriteria.java
+++ b/api/src/main/java/org/hawkular/alerts/api/services/AlertsCriteria.java
@@ -38,6 +38,7 @@ public class AlertsCriteria {
     String tagQuery = null;
     String query = null;
     boolean thin = false;
+    boolean historyOnly = false;
 
     public AlertsCriteria() {
         super();
@@ -46,7 +47,7 @@ public class AlertsCriteria {
     public AlertsCriteria(Long startTime, Long endTime, String alertIds, String triggerIds,
                           String statuses, String severities, String tagQuery, Long startResolvedTime,
                           Long endResolvedTime, Long startAckTime, Long endAckTime, Long startStatusTime,
-                          Long endStatusTime, Boolean thin, String query) {
+                          Long endStatusTime, Boolean thin, Boolean historyOnly, String query) {
         setStartTime(startTime);
         setEndTime(endTime);
         if (!isEmpty(alertIds)) {
@@ -78,6 +79,9 @@ public class AlertsCriteria {
         setEndStatusTime(endStatusTime);
         if (null != thin) {
             setThin(thin.booleanValue());
+        }
+        if (null != historyOnly) {
+            setHistoryOnly(historyOnly.booleanValue());
         }
         setQuery(query);
     }
@@ -453,8 +457,17 @@ public class AlertsCriteria {
         return thin;
     }
 
+    public boolean isHistoryOnly() {
+        return historyOnly;
+    }
+
+
     public void setThin(boolean thin) {
         this.thin = thin;
+    }
+
+    public void setHistoryOnly(boolean historyOnly) {
+        this.historyOnly = historyOnly;
     }
 
     public boolean hasAlertIdCriteria() {
@@ -525,7 +538,8 @@ public class AlertsCriteria {
                 ", triggerId='" + triggerId + '\'' +
                 ", triggerIds=" + triggerIds +
                 ", tagQuery='" + tagQuery + '\'' +
-                ", thin=" + thin +
+                ", thin=" + thin + '\'' +
+                ", historyOnly=" + historyOnly +
                 '}';
     }
 

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnAlertsServiceImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnAlertsServiceImpl.java
@@ -4,6 +4,7 @@ import org.apache.lucene.search.Sort;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.hawkular.alerts.api.model.Note;
 import org.hawkular.alerts.api.model.condition.ConditionEval;
+import org.hawkular.alerts.api.model.condition.EventConditionEval;
 import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.event.Alert;
 import org.hawkular.alerts.api.model.event.Alert.Status;
@@ -401,12 +402,28 @@ public class IspnAlertsServiceImpl implements AlertsService {
 
             // TODO Replace with projection?
             final boolean thinAlerts = criteria.isThin();
+            final boolean historyOnly = criteria.isHistoryOnly();
             List<Alert> alerts = ispnEvents.stream().map(ispnEvent -> {
                 if (thinAlerts) {
                     Alert alert = new Alert((Alert) ispnEvent.getEvent());
                     alert.setDampening(null);
                     alert.setEvalSets(null);
                     alert.setResolvedEvalSets(null);
+                    return alert;
+                }
+                if (historyOnly) {
+                    Alert alert = new Alert((Alert) ispnEvent.getEvent());
+                    alert.setLifecycle(null);
+                    alert.setDampening(null);
+                    alert.setResolvedEvalSets(null);
+                    alert.setTrigger(null);
+                    List<Set<ConditionEval>> setList = alert.getEvalSets();
+                    for (Set<ConditionEval> set : setList) {
+                        EventConditionEval ece = (EventConditionEval) set.iterator().next();
+                        ece.setDisplayString(null);
+                        Event event = ece.getValue();
+                        event.setFacts(null);
+                    }
                     return alert;
                 }
                 return (Alert) ispnEvent.getEvent();

--- a/external/src/main/java/com/redhat/cloud/policies/engine/handlers/AlertsHandler.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/handlers/AlertsHandler.java
@@ -63,6 +63,7 @@ public class AlertsHandler {
     private static final String PARAM_TEXT = "text";
     private static final String PARAM_TAG_NAMES = "tagNames";
     private static final String PARAM_THIN = "thin";
+    private static final String PARAM_HISTORY_ONLY = "historyOnly";
     private static final String PARAM_RESOLVED_BY = "resolvedBy";
     private static final String PARAM_RESOLVED_NOTES = "resolvedNotes";
 
@@ -85,7 +86,8 @@ public class AlertsHandler {
                 PARAM_END_ACK_TIME,
                 PARAM_START_STATUS_TIME,
                 PARAM_END_STATUS_TIME,
-                PARAM_THIN);
+                PARAM_THIN,
+                PARAM_HISTORY_ONLY);
         queryParamValidationMap.put(FIND_ALERTS, new HashSet<>(ALERTS_CRITERIA));
         queryParamValidationMap.get(FIND_ALERTS).addAll(ResponseUtil.PARAMS_PAGING);
         queryParamValidationMap.put(WATCH_ALERTS, new HashSet<>(ALERTS_CRITERIA));
@@ -786,6 +788,7 @@ public class AlertsHandler {
         Long startStatusTime = null;
         Long endStatusTime = null;
         boolean thin = false;
+        boolean historyOnly = false;
 
         if (params.get(PARAM_START_TIME) != null) {
             startTime = Long.valueOf(params.get(PARAM_START_TIME));
@@ -832,8 +835,11 @@ public class AlertsHandler {
         if (params.get(PARAM_THIN) != null) {
             thin = Boolean.valueOf(params.get(PARAM_THIN));
         }
+        if (params.get(PARAM_HISTORY_ONLY) != null) {
+            historyOnly = Boolean.valueOf(params.get(PARAM_HISTORY_ONLY));
+        }
         return new AlertsCriteria(startTime, endTime, alertIds, triggerIds, statuses, severities,
                 tagQuery, startResolvedTime, endResolvedTime, startAckTime, endAckTime, startStatusTime,
-                endStatusTime, thin, query);
+                endStatusTime, thin, historyOnly, query);
     }
 }


### PR DESCRIPTION
This is a different variant of #106 which mimics the 'thin=true' behaviour to (mostly) return history related items. 
Some of the simple fields could still be nulled out to speed up serialisation to JSON a bit more.