### PR TITLE
POL-341 Use "updated" as the timestamp for the notification

### DIFF
--- a/external/src/main/java/com/redhat/cloud/policies/engine/actions/plugins/NotificationActionPluginListener.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/actions/plugins/NotificationActionPluginListener.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -84,7 +85,6 @@ public class NotificationActionPluginListener implements ActionPluginListener {
         Action notificationAction = new Action();
         notificationAction.setEventType(EVENT_TYPE_NAME);
         notificationAction.setApplication(APP_NAME);
-        notificationAction.setTimestamp(LocalDateTime.ofInstant(Instant.ofEpochMilli(actionMessage.getAction().getCtime()), ZoneId.systemDefault()));
         notificationAction.setEventId(actionMessage.getAction().getEventId());
         List<Tag> tags = new ArrayList<>();
         for (Map.Entry<String, String> tagEntry : actionMessage.getAction().getEvent().getTags().entries()) {
@@ -117,6 +117,7 @@ public class NotificationActionPluginListener implements ActionPluginListener {
                 if (conditionEval instanceof EventConditionEval) {
                     EventConditionEval eventEval = (EventConditionEval) conditionEval;
                     addToMessage(notificationAction, "policy_condition", eventEval.getCondition().getExpression());
+                    notificationAction.setTimestamp(LocalDateTime.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(eventEval.getContext().get("check_in"))));
 
                     addToMessage(notificationAction, "insights_id", eventEval.getContext().get("insights_id"));
                     addToMessage(notificationAction, "display_name", eventEval.getValue().getTags().get("display_name").iterator().next());
@@ -130,7 +131,6 @@ public class NotificationActionPluginListener implements ActionPluginListener {
         }
 
         notificationAction.setParams(paramsBuilder.build());
-
         channel.send(serializeAction(notificationAction));
     }
 

--- a/external/src/main/java/com/redhat/cloud/policies/engine/process/Receiver.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/process/Receiver.java
@@ -58,6 +58,7 @@ public class Receiver {
     public static final String INVENTORY_ID_FIELD = "inventory_id";
     public static final String HOST_ID = "id";
     public static final String FQDN_NAME_FIELD = "fqdn";
+    public static final String UPDATED = "updated";
 
     private static final String HOST_FIELD = "host";
     private static final String TYPE_FIELD = "type";
@@ -70,6 +71,7 @@ public class Receiver {
     private static final String TAGS_FIELD = "tags";
     private static final String TAGS_KEY_FIELD = "key";
     private static final String TAGS_VALUE_FIELD = "value";
+    private static final String CHECK_IN_FIELD = "check_in";
 
     @ConfigProperty(name = "engine.receiver.store-events")
     boolean storeEvents;
@@ -149,6 +151,7 @@ public class Receiver {
         // Additional context for processing
         Map<String, String> contextMap = new HashMap<>();
         contextMap.put(INSIGHT_ID_FIELD, insightsId);
+        contextMap.put(CHECK_IN_FIELD, json.getString(UPDATED));
         event.setContext(contextMap);
 
         JsonObject sp = json.getJsonObject(SYSTEM_PROFILE_FIELD);


### PR DESCRIPTION
Haven't tested with real data. I'm using `updated` because that's the value that appearas to be used in inventory as "Last Check-in". That value (updated) also appears in inventory API: `https://cloud.redhat.com/api/inventory/v1/hosts/{the-id}`