### PR TITLE
POL-432 Assign the tenantId early to avoid "TenantId must be not null…

### DIFF
--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnDefinitionsServiceImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnDefinitionsServiceImpl.java
@@ -399,11 +399,14 @@ public class IspnDefinitionsServiceImpl implements DefinitionsService {
         if (TriggerType.MEMBER == type) {
             throw new IllegalArgumentException("FullTrigger.Trigger is type MEMBER and must be updated via the group");
         }
+
+        // Checks (and assigns if needed) the tenantId early.
+        checkTenantId(tenantId, trigger);
+
         if (!isEmpty(trigger.getActions())) {
             enrichManagedActionPluginId(trigger);
         }
 
-        checkTenantId(tenantId, trigger);
         String triggerId = trigger.getId();
 
         // fetch the trigger (or throw NotFoundException)


### PR DESCRIPTION
…" error

 - This happened when we added new actions to existing triggers, preventing
   from finishing the process.