### PR TITLE
Add a scheduled handler to print a heartbeat message.

### DIFF
--- a/external/src/main/java/com/redhat/cloud/policies/engine/metrics/HeartbeatHandler.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/metrics/HeartbeatHandler.java
@@ -1,0 +1,46 @@
+package com.redhat.cloud.policies.engine.metrics;
+
+import io.quarkus.scheduler.Scheduled;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.annotation.Metric;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.logging.Logger;
+
+/**
+ * Log a heart beat message with some stats
+ */
+@ApplicationScoped
+public class HeartbeatHandler {
+
+    private final Logger log = Logger.getLogger(this.getClass().getSimpleName());
+
+
+    // The following metrics are defined in process.Receiver
+    @Inject
+    @Metric(absolute = true, name = "engine.input.processed", tags = {"queue=host-egress"})
+    Counter incomingMessagesCount;
+
+    @Inject
+    @Metric(absolute = true, name = "engine.input.rejected", tags = {"queue=host-egress"})
+    Counter rejectedCount;
+
+    @Inject
+    @Metric(absolute = true, name = "engine.input.processed.errors", tags = {"queue=host-egress"})
+    Counter processingErrors;
+
+
+    @Scheduled(every = "1h")
+    void printHeartbeat() {
+
+        String msg = String.format("Heartbeat: processed %d, rejected %d, process errors %d",
+                incomingMessagesCount.getCount(),
+                rejectedCount.getCount(),
+                processingErrors.getCount());
+
+        log.info(msg);
+
+
+    }
+}


### PR DESCRIPTION
This then prints a message to the log like the following once an hour (manually added a bogus message via kafkacat).
It basically shows the receiver stats for now. We can add more (like number of messages forwarded to notifications).

It is not meant to replace metrics via Prometheus/Grafana and alerting on them, but rather to show a sign of life in the logs.

`2021-01-25 11:22:19,005 INFO  [HeartbeatHandler] (executor-thread-1) Heartbeat: processed 1, rejected 0, process errors 1
`