### PR TITLE
Add a way to set the engine's liveness to admin-down.

### DIFF
--- a/external/src/main/java/com/redhat/cloud/policies/engine/handlers/AdminHandler.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/handlers/AdminHandler.java
@@ -45,6 +45,15 @@ public class AdminHandler {
         router.put(path + "/cleanup").handler(this::cleanupExpiredItems);
         router.get(path + "/stats").handler(this::getKeyStatistics);
         router.put(path + "/rocksdb/compact").handler(this::rocksOperations);
+        router.put(path + "/down").handler(this::setAdminDown);
+    }
+
+    private void setAdminDown(RoutingContext routing) {
+        LivenessHandler.markAsDown();
+        routing.response()
+                .setStatusCode(204)
+                .end();
+        log.info("Admin down handler was invoked");
     }
 
     void executeCleanup() {

--- a/external/src/main/java/com/redhat/cloud/policies/engine/handlers/LivenessHandler.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/handlers/LivenessHandler.java
@@ -10,8 +10,18 @@ import javax.enterprise.context.ApplicationScoped;
 @ApplicationScoped
 public class LivenessHandler implements HealthCheck {
 
+    private static boolean isUp = true;
+
+    public static void markAsDown() {
+        LivenessHandler.isUp = false;
+    }
+
     @Override
     public HealthCheckResponse call() {
-        return HealthCheckResponse.up("Policies Engine has started");
+        if (isUp) {
+            return HealthCheckResponse.up("Policies Engine has started");
+        } else {
+            return HealthCheckResponse.down("Policies Engine was marked as down");
+        }
     }
 }


### PR DESCRIPTION
This requires a put-request to /admin/down. There is currently no other protection other than the assumption that this is behind a secured gateway.