### PR TITLE
Remove insights_id and add inventory_id (id)

### DIFF
--- a/external/src/main/java/com/redhat/cloud/policies/engine/actions/plugins/NotificationActionPluginListener.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/actions/plugins/NotificationActionPluginListener.java
@@ -100,7 +100,7 @@ public class NotificationActionPluginListener implements ActionPluginListener {
                     EventConditionEval eventEval = (EventConditionEval) conditionEval;
 
                     context.setSystemCheckIn(LocalDateTime.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(eventEval.getContext().get("check_in"))));
-                    context.setInsightsId(eventEval.getContext().get("insights_id"));
+                    context.setInventoryId(eventEval.getContext().get("inventory_id"));
                     context.setDisplayName(eventEval.getValue().getTags().get("display_name").iterator().next());
 
                     PoliciesAction.Event event = new PoliciesAction.Event();

--- a/external/src/main/java/com/redhat/cloud/policies/engine/actions/plugins/notification/PoliciesAction.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/actions/plugins/notification/PoliciesAction.java
@@ -140,7 +140,7 @@ public class PoliciesAction {
             }
         }
 
-        private String insightsId;
+        private String inventoryId;
 
         @JsonFormat(shape = JsonFormat.Shape.STRING)
         @JsonSerialize(using = IsoDateTimeSerializer.class)
@@ -155,12 +155,12 @@ public class PoliciesAction {
             tags = new HashMap<>();
         }
 
-        public String getInsightsId() {
-            return insightsId;
+        public String getInventoryId() {
+            return inventoryId;
         }
 
-        public void setInsightsId(String insightsId) {
-            this.insightsId = insightsId;
+        public void setInventoryId(String inventoryId) {
+            this.inventoryId = inventoryId;
         }
 
         public LocalDateTime getSystemCheckIn() {

--- a/external/src/main/java/com/redhat/cloud/policies/engine/process/Receiver.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/process/Receiver.java
@@ -53,7 +53,6 @@ public class Receiver {
     public static final String INSIGHTS_REPORT_DATA_ID = "platform.inventory.host-egress";
 
     public static final String CATEGORY_NAME = "insight_report";
-    public static final String INSIGHT_ID_FIELD = "insights_id";
     public static final String DISPLAY_NAME_FIELD = "display_name";
     public static final String INVENTORY_ID_FIELD = "inventory_id";
     public static final String HOST_ID = "id";
@@ -149,9 +148,9 @@ public class Receiver {
             return input.ack();
         }
 
-        String insightsId = json.getString(INSIGHT_ID_FIELD);
+        String inventoryId = json.getString(HOST_ID);
 
-        if (isEmpty(insightsId)) {
+        if (isEmpty(inventoryId)) {
             rejectedCount.inc();
             rejectedCountId.inc();
             return input.ack();
@@ -159,7 +158,7 @@ public class Receiver {
 
         String tenantId = json.getString(TENANT_ID_FIELD);
         String displayName = json.getString(DISPLAY_NAME_FIELD);
-        String text = String.format("host-egress report %s for %s", insightsId, displayName);
+        String text = String.format("host-egress report %s for %s", inventoryId, displayName);
 
         Event event = new Event(tenantId, UUID.randomUUID().toString(), INSIGHTS_REPORT_DATA_ID, CATEGORY_NAME, text);
         // Indexed searchable events
@@ -170,7 +169,7 @@ public class Receiver {
 
         // Additional context for processing
         Map<String, String> contextMap = new HashMap<>();
-        contextMap.put(INSIGHT_ID_FIELD, insightsId);
+        contextMap.put(INVENTORY_ID_FIELD, inventoryId);
         contextMap.put(CHECK_IN_FIELD, json.getString(UPDATED));
         event.setContext(contextMap);
 

--- a/external/src/test/java/com/redhat/cloud/policies/engine/process/ReceiverFilterTest.java
+++ b/external/src/test/java/com/redhat/cloud/policies/engine/process/ReceiverFilterTest.java
@@ -70,12 +70,12 @@ public class ReceiverFilterTest {
     }
 
     @Test
-    public void testFilterWithoutInsightsId() throws Exception {
+    public void testFilterWithoutInventoryId() throws Exception {
         InputStream is = getClass().getClassLoader().getResourceAsStream("input/host.json");
         String inputJson = IOUtils.toString(is, StandardCharsets.UTF_8);
 
         JsonObject jsonObject = new JsonObject(inputJson);
-        jsonObject.getJsonObject("host").remove("insights_id");
+        jsonObject.getJsonObject("host").remove("id");
         inputJson = jsonObject.toString();
 
         CompletionStage<Void> voidCompletionStage = receiver.processAsync(Message.of(inputJson));

--- a/external/src/test/java/com/redhat/cloud/policies/engine/process/ReceiverTest.java
+++ b/external/src/test/java/com/redhat/cloud/policies/engine/process/ReceiverTest.java
@@ -161,7 +161,7 @@ public class ReceiverTest {
         Action action = deserializeAction(testSubscriber.values().get(0));
 
         assertEquals(TENANT_ID, action.getAccountId());
-        assertTrue(action.getContext().containsKey("insights_id"));
+        assertTrue(action.getContext().containsKey("inventory_id"));
         assertEquals(2, action.getEvents().size());
 
         // Now send broken data and then working and expect things to still work


### PR DESCRIPTION
-  insights_id: An ID defined in /etc/insights-client/machine-id. This field is considered a canonical fact.
-  id: A durable and reliable platform-wide host identifier. Applications  should use this identifier to reference hosts.