### PR TITLE
Print whitelisted env vars and conf values at application startup

### DIFF
--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnAlertsServiceImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnAlertsServiceImpl.java
@@ -80,8 +80,8 @@ public class IspnAlertsServiceImpl implements AlertsService {
     boolean saveThinAlerts = false;
 
     public void init() {
-        alertsLifespanInHours = ConfigProvider.getConfig().getValue("engine.backend.ispn.alerts-lifespan", Long.class);
         eventLifespanInHours = ConfigProvider.getConfig().getValue("engine.backend.ispn.events-lifespan", Long.class);
+        alertsLifespanInHours = ConfigProvider.getConfig().getValue("engine.backend.ispn.alerts-lifespan", Long.class);
         saveThinAlerts = ConfigProvider.getConfig().getValue("engine.backend.ispn.alerts-thin", Boolean.class);
         backend = IspnCacheManager.getCacheManager().getCache("backend");
         if (backend == null) {

--- a/external/src/main/java/com/redhat/cloud/policies/engine/AlertStarter.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/AlertStarter.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.policies.engine;
 import com.redhat.cloud.policies.engine.actions.QuarkusActionPluginRegister;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.hawkular.alerts.AlertsStandalone;
 import org.hawkular.alerts.api.services.ActionsService;
 import org.hawkular.alerts.api.services.AlertsService;
@@ -16,6 +17,10 @@ import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static org.hawkular.alerts.api.util.Util.isEmpty;
 
@@ -49,6 +54,7 @@ public class AlertStarter {
     }
 
     void startApp(@Observes StartupEvent startup) {
+        printEnvVars();
         String commit = System.getenv(BUILD_COMMIT_ENV_NAME);
         if(!isEmpty(commit)) {
             LOGGER.infof("Starting Policies Engine, build: %s", commit);
@@ -56,6 +62,39 @@ public class AlertStarter {
             LOGGER.info("Starting Policies Engine.");
         }
         initialize();
+    }
+
+    private void printEnvVars() {
+        LOGGER.info("=== ENVIRONMENT VARIABLES - START ===");
+        for (Map.Entry<String, String> var : System.getenv().entrySet()) {
+            String value = isWhitelisted(var.getKey()) ? var.getValue() : "NOT_WHITELISTED";
+            LOGGER.info(var.getKey() + "=" + value);
+        }
+        LOGGER.info("=== ENVIRONMENT VARIABLES - END ===");
+        LOGGER.info("=== QUARKUS CONFIG - START ===");
+        for (String key : ConfigProvider.getConfig().getPropertyNames()) {
+            if (key.startsWith("engine")) {
+                ConfigProvider.getConfig().getOptionalValue(key, String.class).ifPresent(value -> {
+                    LOGGER.info(key + "=" + value);
+                });
+            }
+        }
+        LOGGER.info("=== QUARKUS CONFIG - END ===");
+    }
+
+    private static final List<String> PREFIX_WHITELIST = List.of(
+            "QUARKUS_LOG_CLOUDWATCH_LOG_STREAM_NAME",
+            "ENGINE",
+            "HOSTNAME"
+    );
+
+    private boolean isWhitelisted(String key) {
+        for (String prefix : PREFIX_WHITELIST) {
+            if (key.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     void stopApp(@Observes ShutdownEvent shutdown) {


### PR DESCRIPTION
⚠️ Temp PR, will be reverted after we're done fixing the issue.

This PR will print all environment variables keys at application startup.

Values will also be printed but only if they start with a String that matches one of the elements of `PREFIX_WHITELIST`.