### PR TITLE
POL-532 Process Kafka messages in a non-blocking way

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -18,6 +18,10 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jackson</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-mutiny</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.antlr</groupId>

--- a/api/src/main/java/org/hawkular/alerts/api/services/AlertsService.java
+++ b/api/src/main/java/org/hawkular/alerts/api/services/AlertsService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.smallrye.mutiny.Uni;
 import org.hawkular.alerts.api.model.condition.ConditionEval;
 import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.event.Alert;
@@ -54,7 +55,7 @@ public interface AlertsService {
      * @param events Set of unpersisted Events.
      * @throws Exception any problem
      */
-    void addEvents(Collection<Event> events) throws Exception;
+    Uni<Void> addEvents(Collection<Event> events) throws Exception;
 
     /**
      * Add the provided tags to the specified events.
@@ -70,7 +71,7 @@ public interface AlertsService {
      * @param events Set of unpersisted Events.
      * @throws Exception any problem
      */
-    void persistEvents(Collection<Event> events) throws Exception;
+    Uni<Void> persistEvents(Collection<Event> events) throws Exception;
 
     /**
      * Add a note on an existing Alert.
@@ -227,7 +228,7 @@ public interface AlertsService {
      * @param events Not null. The events to be evaluated by the alerting engine.
      * @throws Exception
      */
-    void sendEvents(Collection<Event> events) throws Exception;
+    Uni<Void> sendEvents(Collection<Event> events) throws Exception;
 
     /**
      * Send events to the engine for alerts evaluation.
@@ -237,5 +238,5 @@ public interface AlertsService {
      * @param ignoreFiltering  An optimization. Set true *only* if you are sure the data is useful for evaluation.
      * @throws Exception
      */
-    void sendEvents(Collection<Event> events, boolean ignoreFiltering) throws Exception;
+    Uni<Void> sendEvents(Collection<Event> events, boolean ignoreFiltering) throws Exception;
 }

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
@@ -619,7 +619,7 @@ public class AlertsEngineImpl implements AlertsEngine, PartitionTriggerListener,
                     }
 
                     handleAlerts();
-                    alertsService.persistEvents(events);
+                    alertsService.persistEvents(events).await().indefinitely();
                     if (distributed && !events.isEmpty()) {
                         /*
                             Generated events on a node should be notified to other nodes for chained triggers

--- a/engine/src/test/java/org/hawkular/alerts/engine/impl/ispn/IspnBaseServiceImplTest.java
+++ b/engine/src/test/java/org/hawkular/alerts/engine/impl/ispn/IspnBaseServiceImplTest.java
@@ -209,7 +209,7 @@ public abstract class IspnBaseServiceImplTest {
                 }
             }
         }
-        alerts.addEvents(newEvents);
+        alerts.addEvents(newEvents).await().indefinitely();
         return eventStartTime;
     }
 

--- a/external/src/main/java/com/redhat/cloud/policies/engine/handlers/EventsHandler.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/handlers/EventsHandler.java
@@ -143,7 +143,7 @@ public class EventsHandler {
                     }
 
                     try {
-                        alertsService.addEvents(Collections.singletonList(event));
+                        alertsService.addEvents(Collections.singletonList(event)).await().indefinitely();
                         future.complete(event);
                     } catch (IllegalArgumentException e) {
                         throw new ResponseUtil.BadRequestException("Bad arguments: " + e.getMessage());
@@ -185,7 +185,7 @@ public class EventsHandler {
                     }
                     try {
                         events.stream().forEach(ev -> ev.setTenantId(tenantId));
-                        alertsService.sendEvents(events);
+                        alertsService.sendEvents(events).await().indefinitely();
                         // log.debugf(Events: ", events);
                         future.complete(events);
                     } catch (IllegalArgumentException e) {

--- a/external/src/test/java/com/redhat/cloud/policies/engine/process/MockedAlertsService.java
+++ b/external/src/test/java/com/redhat/cloud/policies/engine/process/MockedAlertsService.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.policies.engine.process;
 
+import io.smallrye.mutiny.Uni;
 import org.hawkular.alerts.api.model.condition.ConditionEval;
 import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.event.Alert;
@@ -36,8 +37,11 @@ public class MockedAlertsService implements AlertsService {
     }
 
     @Override
-    public void addEvents(Collection<Event> events) throws Exception {
-        pushedEvents.addAll(events);
+    public Uni<Void> addEvents(Collection<Event> events) throws Exception {
+        return Uni.createFrom().item(() -> {
+            pushedEvents.addAll(events);
+            return null;
+        });
     }
 
     @Override
@@ -46,8 +50,8 @@ public class MockedAlertsService implements AlertsService {
     }
 
     @Override
-    public void persistEvents(Collection<Event> events) throws Exception {
-
+    public Uni<Void> persistEvents(Collection<Event> events) throws Exception {
+        return Uni.createFrom().nullItem();
     }
 
     @Override
@@ -126,13 +130,16 @@ public class MockedAlertsService implements AlertsService {
     }
 
     @Override
-    public void sendEvents(Collection<Event> events) throws Exception {
-        pushedEvents.addAll(events);
+    public Uni<Void> sendEvents(Collection<Event> events) throws Exception {
+        return Uni.createFrom().item(() -> {
+            pushedEvents.addAll(events);
+            return null;
+        });
     }
 
     @Override
-    public void sendEvents(Collection<Event> events, boolean ignoreFiltering) throws Exception {
-
+    public Uni<Void> sendEvents(Collection<Event> events, boolean ignoreFiltering) throws Exception {
+        return Uni.createFrom().nullItem();
     }
 
     public List<Event> getPushedEvents() {

--- a/external/src/test/java/com/redhat/cloud/policies/engine/process/ReceiverFilterTest.java
+++ b/external/src/test/java/com/redhat/cloud/policies/engine/process/ReceiverFilterTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.TestInstance;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -33,8 +32,7 @@ public class ReceiverFilterTest {
         InputStream is = getClass().getClassLoader().getResourceAsStream("input/host.json");
         String inputJson = IOUtils.toString(is, StandardCharsets.UTF_8);
 
-        CompletionStage<Void> voidCompletionStage = receiver.processAsync(Message.of(inputJson));
-        voidCompletionStage.toCompletableFuture().get();
+        receiver.processAsync(Message.of(inputJson)).await().indefinitely();
 
         assertEquals(1, mockedAlertsService.getPushedEvents().size());
         assertEquals(1, incomingMessagesCount.getCount());
@@ -78,8 +76,7 @@ public class ReceiverFilterTest {
         jsonObject.getJsonObject("host").remove("id");
         inputJson = jsonObject.toString();
 
-        CompletionStage<Void> voidCompletionStage = receiver.processAsync(Message.of(inputJson));
-        voidCompletionStage.toCompletableFuture().get();
+        receiver.processAsync(Message.of(inputJson)).await().indefinitely();
 
         assertEquals(0, mockedAlertsService.getPushedEvents().size());
         assertEquals(1, incomingMessagesCount.getCount());
@@ -91,8 +88,7 @@ public class ReceiverFilterTest {
         InputStream is = getClass().getClassLoader().getResourceAsStream("input/host.json");
         String inputJson = IOUtils.toString(is, StandardCharsets.UTF_8);
 
-        CompletionStage<Void> voidCompletionStage = receiver.processAsync(Message.of(inputJson));
-        voidCompletionStage.toCompletableFuture().get();
+        receiver.processAsync(Message.of(inputJson)).await().indefinitely();
 
         assertEquals("ba11a21a-8b22-431b-9b4b-b06006472d54", mockedAlertsService.getPushedEvents().get(0).getTags().get(Receiver.INVENTORY_ID_FIELD).iterator().next());
     }
@@ -106,8 +102,7 @@ public class ReceiverFilterTest {
         jsonObject.put("type", "deleted");
         inputJson = jsonObject.toString();
 
-        CompletionStage<Void> voidCompletionStage = receiver.processAsync(Message.of(inputJson));
-        voidCompletionStage.toCompletableFuture().get();
+        receiver.processAsync(Message.of(inputJson)).await().indefinitely();
 
         assertEquals(0, mockedAlertsService.getPushedEvents().size());
         assertEquals(1, incomingMessagesCount.getCount());
@@ -120,8 +115,7 @@ public class ReceiverFilterTest {
         jsonObject.getJsonObject("host").put("reporter", "rhsm-conduit");
         inputJson = jsonObject.toString();
 
-        voidCompletionStage = receiver.processAsync(Message.of(inputJson));
-        voidCompletionStage.toCompletableFuture().get();
+        receiver.processAsync(Message.of(inputJson)).await().indefinitely();
 
         assertEquals(0, mockedAlertsService.getPushedEvents().size());
         assertEquals(2, incomingMessagesCount.getCount());


### PR DESCRIPTION
This may fix the `VertxException` we have on prod.

Even if it does not fix the exception, it is still an improvement: Kafka messages are now processed in a non-blocking way.