### PR TITLE
Lower the number of objects stored in the heap old gen

### DIFF
--- a/api/src/main/java/org/hawkular/alerts/api/model/Lifecycle.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/Lifecycle.java
@@ -39,10 +39,10 @@ public class Lifecycle implements Serializable {
         }
         this.status = lifeCycle.getStatus();
         this.stime = lifeCycle.getStime();
-        this.notes = new ArrayList<>();
-        lifeCycle.getNotes().stream().forEach(n -> {
-            notes.add(new Note(n));
-        });
+        notes = new ArrayList<>(lifeCycle.getNotes().size());
+        for (int i = 0; i < lifeCycle.getNotes().size(); i++) {
+            notes.add(new Note(lifeCycle.getNotes().get(i)));
+        }
     }
 
     public Lifecycle(String status, long stime) {

--- a/api/src/main/java/org/hawkular/alerts/api/model/trigger/Trigger.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/trigger/Trigger.java
@@ -52,6 +52,7 @@ import static org.hawkular.alerts.api.util.Util.isEmpty;
 public class Trigger implements Serializable {
 
     private static final long serialVersionUID = 1L;
+    private static final float HASHSET_DEFAULT_LOAD_FACTOR = 0.75f;
 
     @DocModelProperty(description = "Tenant id owner of this trigger.", position = 0, required = true, allowableValues = "Tenant is overwritten from Hawkular-Tenant HTTP header parameter request")
     @JsonInclude
@@ -227,7 +228,7 @@ public class Trigger implements Serializable {
         this.context = new HashMap<>(trigger.getContext());
         this.tags = tagsBuilder();
         this.tags.putAll(trigger.getTags());
-        this.actions = new HashSet<>();
+        actions = new HashSet<>((int) Math.ceil(trigger.getActions().size() / HASHSET_DEFAULT_LOAD_FACTOR) + 1);
         for (TriggerAction action : trigger.getActions()) {
             this.actions.add(new TriggerAction(action));
         }
@@ -247,11 +248,10 @@ public class Trigger implements Serializable {
         this.type = trigger.getType();
         this.source = trigger.getSource();
         this.severity = trigger.getSeverity();
-        this.lifecycle = new ArrayList<>();
-        trigger.getLifecycle()
-                .forEach(l -> {
-                    this.lifecycle.add(new Lifecycle(l));
-                });
+        lifecycle = new ArrayList<>(trigger.getLifecycle().size());
+        for (int i = 0; i < trigger.getLifecycle().size(); i++) {
+            lifecycle.add(new Lifecycle(trigger.getLifecycle().get(i)));
+        }
 
         this.mode = trigger.getMode() != null ? trigger.getMode() : Mode.FIRING;
         this.match = trigger.getMode() == Mode.FIRING ? trigger.getFiringMatch() : trigger.getAutoResolveMatch();

--- a/engine/src/main/java/org/hawkular/alerts/engine/cache/ActionsCacheManager.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/cache/ActionsCacheManager.java
@@ -14,7 +14,10 @@ import org.hawkular.alerts.api.services.DefinitionsService;
 
 import org.hawkular.alerts.log.AlertingLogger;
 import org.hawkular.alerts.log.MsgLogging;
+import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
+
+import static org.infinispan.context.Flag.IGNORE_RETURN_VALUES;
 
 /**
  * It manages the cache of global actions.
@@ -27,14 +30,14 @@ public class ActionsCacheManager {
 
     DefinitionsService definitions;
 
-    private Cache<ActionKey, ActionDefinition> globalActionsCache;
+    private AdvancedCache<ActionKey, ActionDefinition> globalActionsCache;
 
     public void setDefinitions(DefinitionsService definitions) {
         this.definitions = definitions;
     }
 
     public void setGlobalActionsCache(Cache<ActionKey, ActionDefinition> globalActionsCache) {
-        this.globalActionsCache = globalActionsCache;
+        this.globalActionsCache = globalActionsCache.getAdvancedCache();
     }
 
     public void init() {
@@ -52,7 +55,7 @@ public class ActionsCacheManager {
                     case ACTION_DEFINITION_UPDATE:
                         ActionDefinition actionDefinition = event.getActionDefinition();
                         if (actionDefinition.isGlobal()) {
-                            globalActionsCache.put(key, actionDefinition);
+                            globalActionsCache.withFlags(IGNORE_RETURN_VALUES).put(key, actionDefinition);
                         }
                         break;
                     case ACTION_DEFINITION_REMOVE:
@@ -87,7 +90,7 @@ public class ActionsCacheManager {
                     ActionKey key = new ActionKey(actionDefinition.getTenantId(),
                             actionDefinition.getActionPlugin(),
                             actionDefinition.getActionId());
-                    globalActionsCache.put(key, actionDefinition);
+                    globalActionsCache.withFlags(IGNORE_RETURN_VALUES).put(key, actionDefinition);
                 }
             }
             globalActionsCache.endBatch(true);

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnActionsServiceImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnActionsServiceImpl.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.hawkular.alerts.api.util.Util.isEmpty;
+import static org.infinispan.context.Flag.IGNORE_RETURN_VALUES;
 
 /**
  * Infinispan implementation of {@link org.hawkular.alerts.api.services.ActionsService}.
@@ -138,7 +139,7 @@ public class IspnActionsServiceImpl implements ActionsService {
             }
             Action existingAction = IspnAction.getAction();
             existingAction.setResult(action.getResult());
-            actionsStore.put(pk, new IspnAction(existingAction));
+            actionsStore.getAdvancedCache().withFlags(IGNORE_RETURN_VALUES).put(pk, new IspnAction(existingAction));
         } catch (Exception e) {
             log.errorDatabaseException(e.getMessage());
             throw e;
@@ -418,9 +419,9 @@ public class IspnActionsServiceImpl implements ActionsService {
         }
         try {
             if(alertsLifespanInHours < 0) {
-                actionsStore.put(IspnPk.pk(action), new IspnAction(action));
+                actionsStore.getAdvancedCache().withFlags(IGNORE_RETURN_VALUES).put(IspnPk.pk(action), new IspnAction(action));
             } else {
-                actionsStore.put(IspnPk.pk(action), new IspnAction(action), alertsLifespanInHours, TimeUnit.HOURS);
+                actionsStore.getAdvancedCache().withFlags(IGNORE_RETURN_VALUES).put(IspnPk.pk(action), new IspnAction(action), alertsLifespanInHours, TimeUnit.HOURS);
             }
         } catch (Exception e) {
             log.errorDatabaseException(e.getMessage());

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnAlertsServiceImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnAlertsServiceImpl.java
@@ -54,6 +54,8 @@ import static org.hawkular.alerts.api.util.Util.isEmpty;
 import static org.hawkular.alerts.engine.impl.ispn.IspnPk.pk;
 import static org.hawkular.alerts.engine.impl.ispn.IspnPk.pkFromEventId;
 
+import static org.infinispan.context.Flag.IGNORE_RETURN_VALUES;
+
 /**
  * @author Jay Shaughnessy
  * @author Lucas Ponce
@@ -115,9 +117,9 @@ public class IspnAlertsServiceImpl implements AlertsService {
             ttl = alertsLifespanInHours;
         }
         if(ttl < 0) {
-            backend.put(pk(event), new IspnEvent(event));
+            backend.getAdvancedCache().withFlags(IGNORE_RETURN_VALUES).put(pk(event), new IspnEvent(event));
         } else {
-            backend.put(pk(event), new IspnEvent(event), ttl, TimeUnit.HOURS);
+            backend.getAdvancedCache().withFlags(IGNORE_RETURN_VALUES).put(pk(event), new IspnEvent(event), ttl, TimeUnit.HOURS);
         }
     }
 

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnDefinitionsServiceImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnDefinitionsServiceImpl.java
@@ -59,6 +59,8 @@ import org.infinispan.query.dsl.FilterConditionContext;
 import org.infinispan.query.dsl.QueryBuilder;
 import org.infinispan.query.dsl.QueryFactory;
 
+import static org.infinispan.context.Flag.IGNORE_RETURN_VALUES;
+
 /**
  * @author Jay Shaughnessy
  * @author Lucas Ponce
@@ -138,7 +140,7 @@ public class IspnDefinitionsServiceImpl implements DefinitionsService {
         if (found != null) {
             throw new FoundException(pk);
         }
-        backend.put(pk(actionDefinition), new IspnActionDefinition(actionDefinition));
+        backend.getAdvancedCache().withFlags(IGNORE_RETURN_VALUES).put(pk(actionDefinition), new IspnActionDefinition(actionDefinition));
 
         notifyListeners(new DefinitionsEvent(ACTION_DEFINITION_CREATE, actionDefinition));
     }
@@ -1344,7 +1346,7 @@ public class IspnDefinitionsServiceImpl implements DefinitionsService {
         if (backend.get(pk) != null) {
             throw new FoundException(pk);
         }
-        backend.put(pk, new IspnActionPlugin(actionPlugin, defaultProperties));
+        backend.getAdvancedCache().withFlags(IGNORE_RETURN_VALUES).put(pk, new IspnActionPlugin(actionPlugin, defaultProperties));
     }
 
     @Override
@@ -1379,7 +1381,7 @@ public class IspnDefinitionsServiceImpl implements DefinitionsService {
             throw new NotFoundException(pk);
         }
         found.setDefaultProperties(defaultProperties);
-        backend.put(pk, found);
+        backend.getAdvancedCache().withFlags(IGNORE_RETURN_VALUES).put(pk, found);
     }
 
     @Override
@@ -1463,7 +1465,7 @@ public class IspnDefinitionsServiceImpl implements DefinitionsService {
         if (found == null) {
             throw new NotFoundException(pk);
         }
-        backend.put(pk, new IspnActionDefinition(actionDefinition));
+        backend.getAdvancedCache().withFlags(IGNORE_RETURN_VALUES).put(pk, new IspnActionDefinition(actionDefinition));
 
         notifyListeners(new DefinitionsEvent(ACTION_DEFINITION_UPDATE, actionDefinition));
     }
@@ -1864,7 +1866,7 @@ public class IspnDefinitionsServiceImpl implements DefinitionsService {
         if (found != null) {
             throw new FoundException(pk);
         }
-        backend.put(pk, new IspnTrigger(trigger));
+        backend.getAdvancedCache().withFlags(IGNORE_RETURN_VALUES).put(pk, new IspnTrigger(trigger));
 
         if (null != alertsEngine) {
             alertsEngine.addTrigger(trigger.getTenantId(), trigger.getId());
@@ -1915,7 +1917,7 @@ public class IspnDefinitionsServiceImpl implements DefinitionsService {
     private Trigger updateTrigger(Trigger trigger, boolean reload) throws Exception {
         log.info("new IspnTrigger: " + trigger.toString());
         String pk = pk(trigger);
-        backend.put(pk, new IspnTrigger(trigger));
+        backend.getAdvancedCache().withFlags(IGNORE_RETURN_VALUES).put(pk, new IspnTrigger(trigger));
         log.info("IspnTrigger Done: " + trigger.getId());
 
         if (null != alertsEngine && reload) {
@@ -2023,7 +2025,7 @@ public class IspnDefinitionsServiceImpl implements DefinitionsService {
 
     private Dampening addDampening(Dampening dampening) throws Exception {
         try {
-            backend.put(pk(dampening), new IspnDampening(dampening));
+            backend.getAdvancedCache().withFlags(IGNORE_RETURN_VALUES).put(pk(dampening), new IspnDampening(dampening));
         } catch (Exception e) {
             log.errorDatabaseException(e.getMessage());
             throw e;
@@ -2186,7 +2188,7 @@ public class IspnDefinitionsServiceImpl implements DefinitionsService {
             String pk = pkFromTriggerId(tenantId, memberTriggerId);
             Trigger memberTrigger = (Trigger) backend.get(pk);
             memberTrigger.setDataIdMap(dataIdMap);
-            backend.put(pk, memberTrigger);
+            backend.getAdvancedCache().withFlags(IGNORE_RETURN_VALUES).put(pk, memberTrigger);
         } catch (Exception e) {
             log.errorDatabaseException(e.getMessage());
             throw e;
@@ -2378,7 +2380,7 @@ public class IspnDefinitionsServiceImpl implements DefinitionsService {
 
     private Dampening updateDampening(Dampening dampening) throws Exception {
         try {
-            backend.put(pk(dampening), new IspnDampening(dampening));
+            backend.getAdvancedCache().withFlags(IGNORE_RETURN_VALUES).put(pk(dampening), new IspnDampening(dampening));
         } catch (Exception e) {
             log.errorDatabaseException(e.getMessage());
             throw e;

--- a/engine/src/main/java/org/hawkular/alerts/filter/CacheClient.java
+++ b/engine/src/main/java/org/hawkular/alerts/filter/CacheClient.java
@@ -6,7 +6,10 @@ import java.util.stream.Collectors;
 
 import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.event.Event;
+import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
+
+import static org.infinispan.context.Flag.IGNORE_RETURN_VALUES;
 
 /**
  * Provide access to the cache of dataIds in use by the global trigger population (not node specific). It is
@@ -22,10 +25,10 @@ public class CacheClient {
 
     // It stores a list of triggerIds used per key (tenantId, dataId).
     // This cache is used by CacheClient to check wich dataIds are published and forwarded from metrics.
-    private Cache<CacheKey, Set<String>> cache;
+    private AdvancedCache<CacheKey, Set<String>> cache;
 
     public void setCache(Cache<CacheKey, Set<String>> cache) {
-        this.cache = cache;
+        this.cache = cache.getAdvancedCache();
     }
 
     public Set<CacheKey> keySet() {
@@ -70,6 +73,6 @@ public class CacheClient {
      *  This is here for testing purposes only and should not be called in production code.
      */
     public void addTestKey(CacheKey key, Set<String> value) {
-        cache.put(key, value);
+        cache.withFlags(IGNORE_RETURN_VALUES).put(key, value);
     }
 }


### PR DESCRIPTION
I use JFR / MissionControl for my `policies-history` work to check the impact of code changes on the prod memory leak (which is really easy to reproduce locally BTW). Heap old gen analysis showed a lot of `ArrayList`/`HashSet` resizes and also cache `read` operations after `put` operations while we don't use the returned values. This PR contains short-term optimizations that will lower the number of objects stored in the old gen. It only mitigates some of the consequences of the leak but does not fix the cause at all. Don't expect a fantastic result, but there will be a slight improvement.

See [this article](https://infinispan.org/blog/2012/09/04/speeding-up-cache-calls-with) about the reason why we should use `Flag.IGNORE_RETURN_VALUES`.