### PR TITLE
POL-450 Enable policies-history by default

### DIFF
--- a/external/src/main/java/com/redhat/cloud/policies/engine/history/PoliciesHistory.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/history/PoliciesHistory.java
@@ -22,7 +22,7 @@ public class PoliciesHistory implements PoliciesHistoryService {
     private static final String INVENTORY_ID_TAG_KEY = "inventory_id";
     private static final String DISPLAY_NAME_TAG_KEY = "display_name";
 
-    @ConfigProperty(name = "engine.policies-history.enabled", defaultValue = "false")
+    @ConfigProperty(name = "engine.policies-history.enabled", defaultValue = "true")
     boolean enabled;
 
     @Inject

--- a/external/src/main/resources/application.properties
+++ b/external/src/main/resources/application.properties
@@ -131,12 +131,7 @@ quarkus.log.cloudwatch.access-key-secret=placeholder
 # It is causing failures when the app is started with quarkus:dev because some parts of our code are not compliant with the CDI spec.
 quarkus.arc.dev-mode.monitoring-enabled=false
 
-# If true, the following property will enable policies history storage into the database defined below.
-engine.policies-history.enabled=false
-
-# The policies history service is enabled during tests.
-%test.engine.policies-history.enabled=true
-# During tests only, the required SQL schema is created using Flyway.
+# During tests only, the SQL schema required for policies history is created using Flyway.
 %test.quarkus.flyway.migrate-at-start=true
 
 # The following database is used to store the policies history data which is then used from the policies-ui-backend project.


### PR DESCRIPTION
This will start persisting the policies-history entries into Postgres on prod.

At least 14 days later, we will enable policies-history in policies-ui-backend. Until then, the ui-backend will still consume the history data from Infinispan.

I am changing this boolean rather than the one in app-interface to keep dev and prod in a synced state. The boolean in app-interface is still there to disable policies-history in case of emergency.