### PR TITLE
Hide Maven downloads progress in build logs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,9 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Cache Maven dependencies
@@ -22,4 +20,4 @@ jobs:
         java-version: 11
         distribution: adopt
     - name: Build with Maven
-      run: ./mvnw -B clean install -Pitest -Dhawkular.data=target/hawkular.data
+      run: ./mvnw -B clean install -Pitest -Dhawkular.data=target/hawkular.data --no-transfer-progress

--- a/external/src/main/docker/Dockerfile-build.jvm
+++ b/external/src/main/docker/Dockerfile-build.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi8/openjdk-11:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -DskipTests
+RUN ./mvnw clean package -DskipTests --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest


### PR DESCRIPTION
Build logs will be much shorter with this in Jenkins and GH.