### PR TITLE
POL-561 Stop persisting triggers history in Infinispan

### DIFF
--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
@@ -109,6 +109,8 @@ public class AlertsEngineImpl implements AlertsEngine, PartitionTriggerListener,
 
     private ExecutorService executor;
 
+    private boolean triggersLifecycleDisabled;
+
     public AlertsEngineImpl() {
         pendingData = new TreeSet<>();
         pendingEvents = new TreeSet<>();
@@ -125,6 +127,10 @@ public class AlertsEngineImpl implements AlertsEngine, PartitionTriggerListener,
         engineExtensions = ConfigProvider.getConfig().getValue("engine.alerts.engine-extensions", Boolean.class);
         updateLastEvaluated = ConfigProvider.getConfig().getValue("engine.alerts.condition-evaluation-time", Boolean.class);
         wakeUpTimer = new Timer("AlertsEngineImpl-Timer");
+    }
+
+    public void disableTriggersLifecycle() {
+        triggersLifecycleDisabled = true;
     }
 
     public RulesEngine getRules() {
@@ -678,8 +684,10 @@ public class AlertsEngineImpl implements AlertsEngine, PartitionTriggerListener,
 
     private void handleAlerts() throws Exception {
         alertsService.addAlerts(alerts);
-        for (Alert alert : alerts) {
-            definitions.addLifecycleToTrigger(alert.getTenantId(), alert.getTriggerId(), Trigger.TriggerLifecycle.ALERT_GENERATE);
+        if (!triggersLifecycleDisabled) {
+            for (Alert alert : alerts) {
+                definitions.addLifecycleToTrigger(alert.getTenantId(), alert.getTriggerId(), Trigger.TriggerLifecycle.ALERT_GENERATE);
+            }
         }
         alerts.clear();
     }

--- a/external/src/main/java/org/hawkular/alerts/AlertsStandalone.java
+++ b/external/src/main/java/org/hawkular/alerts/AlertsStandalone.java
@@ -3,6 +3,7 @@ package org.hawkular.alerts;
 import com.redhat.cloud.policies.engine.actions.QuarkusActionPluginRegister;
 import io.quarkus.runtime.LaunchMode;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.hawkular.alerts.api.services.ActionsService;
 import org.hawkular.alerts.api.services.PoliciesHistoryService;
 import org.hawkular.alerts.api.services.AlertsService;
@@ -55,6 +56,10 @@ public class AlertsStandalone {
 
     @Inject
     PoliciesHistoryService policiesHistoryService;
+
+    // The triggers' lifecycle is no longer used by policies-ui-backend. It has been replaced with a Postgres table.
+    @ConfigProperty(name = "engine.triggers-lifecycle.disabled", defaultValue = "false")
+    boolean triggersLifecycleDisabled;
 
     //    @ConfigProperty(name = "engine.backend.ispn.reindex", defaultValue = "false")
     private boolean ispnReindex;
@@ -160,6 +165,10 @@ public class AlertsStandalone {
     @PostConstruct
     void postConstruct() {
         ispnAlerts.setPoliciesHistoryService(policiesHistoryService);
+        if (triggersLifecycleDisabled) {
+            log.info("Triggers lifecycle is disabled");
+            engine.disableTriggersLifecycle();
+        }
     }
 
     public void init() {

--- a/external/src/main/resources/application.properties
+++ b/external/src/main/resources/application.properties
@@ -149,3 +149,5 @@ quarkus.hibernate-orm.physical-naming-strategy=com.redhat.cloud.policies.engine.
 
 # Quarkus since 1.11 redirects non-apps to /q/. We need to prevent this
 quarkus.http.non-application-root-path=/
+
+engine.triggers-lifecycle.disabled=true

--- a/external/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
+++ b/external/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
@@ -12,6 +12,7 @@ import org.hawkular.alerts.api.model.trigger.Mode
 import org.hawkular.alerts.api.model.trigger.Trigger
 import org.hawkular.alerts.log.MsgLogger
 import org.hawkular.alerts.log.MsgLogging
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
@@ -325,6 +326,7 @@ class LifecycleITest extends AbstractQuarkusITestBase {
     }
 
     @Test
+    @Disabled("The triggers' lifecycle is no longer used by policies-ui-backend. This is still an experimental change so let's keep this test around for a while.")
     void t031_verifyTriggerLifecycle() {
         logger.info( "Running t022_verifyTriggerLifecycle")
         def resp = client.get(path: "triggers/trigger/test-autoresolve-trigger");


### PR DESCRIPTION
This PR disables the triggers lifecycle which means that when a trigger is fired, it will no longer:
- be loaded from Infinispan
- have its lifecycle updated
- be saved into Infinispan

ℹ️ This is tested with IQE tests on ephemeral and they all passed.