### PR TITLE
Lower the alerts lifespan to 24 hours

### DIFF
--- a/external/src/main/resources/application.properties
+++ b/external/src/main/resources/application.properties
@@ -65,7 +65,7 @@ engine.backend.ispn.reindex=false
 engine.backend.ispn.events-lifespan=1
 
 # How many hours do we retain the alerts. Set to negative value to store forever
-engine.backend.ispn.alerts-lifespan=168
+engine.backend.ispn.alerts-lifespan=24
 %test.engine.backend.ispn.alerts-lifespan=1
 
 # Used to clean triggers and data cache, defined in milliseconds


### PR DESCRIPTION
This should help reducing the amount of data stored in Infinispan.

AFAIU, alerts are processed by the engine almost immediately and transformed into actions sent as Kafka payloads on the `ingress` topic. After that, I don't see why we would need to keep the alerts in the cache.

This change will be fully effective 7 days after the redeployment because the old alerts will still be stored for 7 days.