### PR TITLE
Disable actions store

### DIFF
--- a/external/src/main/resources/application.properties
+++ b/external/src/main/resources/application.properties
@@ -151,3 +151,4 @@ quarkus.hibernate-orm.physical-naming-strategy=com.redhat.cloud.policies.engine.
 quarkus.http.non-application-root-path=/
 
 engine.triggers-lifecycle.disabled=true
+engine.actions-store.disabled=true

--- a/external/src/test/groovy/org/hawkular/alerts/rest/ActionsITest.groovy
+++ b/external/src/test/groovy/org/hawkular/alerts/rest/ActionsITest.groovy
@@ -11,6 +11,7 @@ import org.hawkular.alerts.api.model.trigger.Trigger
 import org.hawkular.alerts.api.model.trigger.TriggerAction
 import org.hawkular.alerts.log.MsgLogger
 import org.hawkular.alerts.log.MsgLogging
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 import static org.hawkular.alerts.api.model.event.Alert.Status
@@ -283,6 +284,7 @@ class ActionsITest extends AbstractQuarkusITestBase {
     }
 
     @Test
+    @Disabled("The actions store is no longer used by the engine. This is still an experimental change so let's keep this test around for a while.")
     void actionByStatusTest() {
         String start = String.valueOf(System.currentTimeMillis());
 
@@ -446,6 +448,7 @@ class ActionsITest extends AbstractQuarkusITestBase {
     }
 
     @Test
+    @Disabled("The actions store is no longer used by the engine. This is still an experimental change so let's keep this test around for a while.")
     void globalActionsTest() {
         String start = String.valueOf(System.currentTimeMillis());
 


### PR DESCRIPTION
This PR may or may not have a significant impact on the stage/prod memory leak. 😄 

I am able to reproduce a memory leak on my machine using JMeter and a large number of incoming Kafka messages on the `platform.inventory.events` topic. As a consequence, I had the occasion to analyze a few heap dumps and to test many code changes.

Here's what I suspect. With the current `master` code, the garbage collector is unable to release the memory allocated to an `Alert` because of the `Action#event` field which holds a reference to the `Alert`. The `Action` is stored in a volatile Infinispan cache for a duration corresponding to the `Alert` lifespan configured in `application.properties` (currently 24h). After that delay, the `Alert` becomes eligible to garbage collection.

I don't think we need to persist even temporarily the actions in Infinispan. Our `ActionListener` immediately transforms each action into a Kafka message sent on `platform.notifications.ingress`, that should be enough for Policies to work. This is why I'd like to deploy this PR on stage and observe the memory afterwards.

If my asumptions are wrong then it will be super easy to revert the code.