### PR TITLE
Bump Quarkus to 2.5.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <version.org.jboss.logging.jboss-logging-tools>2.2.1.Final</version.org.jboss.logging.jboss-logging-tools>
 
     <!-- Quarkus -->
-    <quarkus.version>2.5.1.Final</quarkus.version>
+    <quarkus.version>2.5.4.Final</quarkus.version>
 
     <!--Distributed tracing support for Vert.x which is not covered by SmallRye-OT -->
     <version.opentracing-vertx-web>1.0.0</version.opentracing-vertx-web>


### PR DESCRIPTION
2.6.0.Final may not be completely stable, let's wait for 2.6.1.Final.