### PR TITLE
Make engine.alerts.engine-period configurable from app-interface

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -88,6 +88,8 @@ objects:
           successThreshold: 1
           failureThreshold: 3
         env:
+        - name: ENGINE_ALERTS_ENGINE_PERIOD
+          value: ${ENGINE_ALERTS_ENGINE_PERIOD}
         - name: ENV_NAME
           value: ${ENV_NAME}
         - name: EXTERNAL_LOGGING_LEVEL
@@ -122,6 +124,9 @@ parameters:
 - name: CPU_REQUEST
   description: CPU request
   value: 500m
+- name: ENGINE_ALERTS_ENGINE_PERIOD
+  description: Delay in milliseconds between two executions of the TimerTask that processes the events
+  value: 2000
 - name: ENV_NAME
   description: ClowdEnvironment name (ephemeral, stage, prod)
   required: true


### PR DESCRIPTION
This PR makes [this config value](https://github.com/RedHatInsights/policies-engine/blob/89ebb1fa7b5a8056aeb1546a957f4e7dbb8d156f/external/src/main/resources/application.properties#L98) configurable from env vars. IIUC, it is used in [AlertsEngineImpl](https://github.com/RedHatInsights/policies-engine/blob/89ebb1fa7b5a8056aeb1546a957f4e7dbb8d156f/engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java#L126) to determine the period between two executions of [RulesInvoker](https://github.com/RedHatInsights/policies-engine/blob/89ebb1fa7b5a8056aeb1546a957f4e7dbb8d156f/engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java#L595) which is where the events are processed and transformed into notifications.

Increasing the period _may_ help alleviate (or even fix, who knows...) the current issue. Or maybe it won't do anything.