### PR TITLE
POL-649 Introduce LightweightEngine

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -102,6 +102,8 @@ objects:
           value: "0"
         - name: _JAVA_OPTIONS
           value: -Dhawkular.data=/data -Dengine.alerts.condition-evaluation-time=false -Dengine.data-driven-triggers-enabled=false
+        - name: LIGHTWEIGHT_ENGINE_ENABLED
+          value: ${LIGHTWEIGHT_ENGINE_ENABLED}
         - name: QUARKUS_HTTP_PORT
           value: "8000"
         - name: QUARKUS_LOG_CLOUDWATCH_ENABLED
@@ -142,6 +144,8 @@ parameters:
   value: 10Gi
 - name: EXTERNAL_LOGGING_LEVEL
   value: INFO
+- name: LIGHTWEIGHT_ENGINE_ENABLED
+  value: "false"
 - name: MEMORY_LIMIT
   description: Memory limit
   value: 3Gi

--- a/api/src/main/java/org/hawkular/alerts/api/services/LightweightEngine.java
+++ b/api/src/main/java/org/hawkular/alerts/api/services/LightweightEngine.java
@@ -1,0 +1,45 @@
+package org.hawkular.alerts.api.services;
+
+import org.hawkular.alerts.api.model.condition.Condition;
+import org.hawkular.alerts.api.model.event.Event;
+import org.hawkular.alerts.api.model.trigger.FullTrigger;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+
+import java.util.Collection;
+
+/**
+ * Simple engine implementation that does not rely on Infinispan or Drools for the Kafka messages processing. This is
+ * the first step of a more important work aimed at making policies-engine simpler.
+ */
+public interface LightweightEngine {
+
+    /**
+     * Adds a trigger to the in-memory collection of known triggers.
+     * @param fullTrigger the trigger to load
+     */
+    void loadTrigger(FullTrigger fullTrigger);
+
+    /**
+     * Updates a trigger in the in-memory collection of known triggers.
+     * @param trigger the trigger to update
+     * @param conditions the trigger conditions
+     */
+    void reloadTrigger(Trigger trigger, Collection<Condition> conditions);
+
+    /**
+     * Removes a trigger from the in-memory collection of known triggers.
+     * @param tenantId the tenant id of the trigger owner
+     * @param triggerId the trigger id
+     */
+    void removeTrigger(String tenantId, String triggerId);
+
+    /**
+     * Processes an {@link Event}, evaluating conditions of all triggers owned by the tenant of the event. If the
+     * conditions of at least one trigger are satisfied, then a Kafka message will be sent to the notifications topic.
+     * If the conditions of multiple triggers are satisfied, one Kafka message is sent and it contains one event for
+     * each trigger that was fired. In that case, tags from each fired trigger are also merged into a single collection
+     * and added to the Kafka payload. Each fired trigger also results in a new record in the policies history DB table.
+     * @param event the event
+     */
+    void process(Event event);
+}

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
@@ -18,6 +18,7 @@ import org.hawkular.alerts.api.services.DataExtension;
 import org.hawkular.alerts.api.services.DefinitionsService;
 import org.hawkular.alerts.api.services.EventExtension;
 import org.hawkular.alerts.api.services.ExtensionsService;
+import org.hawkular.alerts.api.services.LightweightEngine;
 import org.hawkular.alerts.engine.impl.AlertsEngineCache.DataEntry;
 import org.hawkular.alerts.engine.service.AlertsEngine;
 import org.hawkular.alerts.engine.service.PartitionDataListener;
@@ -111,6 +112,8 @@ public class AlertsEngineImpl implements AlertsEngine, PartitionTriggerListener,
 
     private boolean triggersLifecycleDisabled;
 
+    private LightweightEngine lightweightEngine;
+
     public AlertsEngineImpl() {
         pendingData = new TreeSet<>();
         pendingEvents = new TreeSet<>();
@@ -163,6 +166,10 @@ public class AlertsEngineImpl implements AlertsEngine, PartitionTriggerListener,
 
     public void setExecutor(ExecutorService executor) {
         this.executor = executor;
+    }
+
+    public void setLightweightEngine(LightweightEngine lightweightEngine) {
+        this.lightweightEngine = lightweightEngine;
     }
 
     public void initServices() {
@@ -381,6 +388,9 @@ public class AlertsEngineImpl implements AlertsEngine, PartitionTriggerListener,
                 if (!dampenings.isEmpty()) {
                     rules.addFacts(dampenings);
                 }
+                if (lightweightEngine != null) {
+                    lightweightEngine.reloadTrigger(trigger, conditionSet);
+                }
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
@@ -404,6 +414,9 @@ public class AlertsEngineImpl implements AlertsEngine, PartitionTriggerListener,
             rules.addFacts(conditions);
             if (!dampenings.isEmpty()) {
                 rules.addFacts(dampenings);
+            }
+            if (lightweightEngine != null) {
+                lightweightEngine.loadTrigger(fullTrigger);
             }
         }
     }
@@ -437,6 +450,9 @@ public class AlertsEngineImpl implements AlertsEngine, PartitionTriggerListener,
             partitionManager.notifyTrigger(Operation.REMOVE, triggerToRemove.getTenantId(), triggerToRemove.getId());
         } else {
             removeTrigger(triggerToRemove);
+        }
+        if (lightweightEngine != null) {
+            lightweightEngine.removeTrigger(triggerToRemove.getTenantId(), triggerToRemove.getId());
         }
     }
 

--- a/external/src/main/java/com/redhat/cloud/policies/engine/LightweightEngineImpl.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/LightweightEngineImpl.java
@@ -102,7 +102,9 @@ public class LightweightEngineImpl implements LightweightEngine {
         Map<String, FullTrigger> tenantTriggers = triggersByTenant.get(tenantId);
         if (tenantTriggers != null) {
             found = tenantTriggers.remove(triggerId) != null;
-            LOGGER.debugf("Trigger removed");
+            if (found) {
+                LOGGER.debugf("Trigger removed");
+            }
         }
         if (!found) {
             LOGGER.debugf("Trigger to remove not found");

--- a/external/src/main/java/com/redhat/cloud/policies/engine/LightweightEngineImpl.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/LightweightEngineImpl.java
@@ -1,0 +1,265 @@
+package com.redhat.cloud.policies.engine;
+
+import com.redhat.cloud.policies.engine.actions.plugins.notification.PoliciesAction;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.OnOverflow;
+import org.hawkular.alerts.api.model.condition.Condition;
+import org.hawkular.alerts.api.model.condition.ConditionEval;
+import org.hawkular.alerts.api.model.condition.EventCondition;
+import org.hawkular.alerts.api.model.condition.EventConditionEval;
+import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.event.Alert;
+import org.hawkular.alerts.api.model.event.Event;
+import org.hawkular.alerts.api.model.trigger.FullTrigger;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+import org.hawkular.alerts.api.services.LightweightEngine;
+import org.hawkular.alerts.api.services.PoliciesHistoryService;
+import org.jboss.logging.Logger;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.redhat.cloud.policies.engine.actions.plugins.NotificationActionPluginListener.WEBHOOK_CHANNEL;
+import static com.redhat.cloud.policies.engine.actions.plugins.NotificationActionPluginListener.buildMessageWithId;
+import static com.redhat.cloud.policies.engine.actions.plugins.NotificationActionPluginListener.serializeAction;
+import static java.time.ZoneOffset.UTC;
+import static org.eclipse.microprofile.reactive.messaging.OnOverflow.Strategy.UNBOUNDED_BUFFER;
+
+@ApplicationScoped
+public class LightweightEngineImpl implements LightweightEngine {
+
+    public static final String LIGHTWEIGHT_ENGINE_CONFIG_KEY = "lightweight-engine.enabled";
+
+    private static final Logger LOGGER = Logger.getLogger(LightweightEngineImpl.class);
+
+    // The key of the outer map is the tenantId. The key of the inner map is the triggerId.
+    private final Map<String, Map<String, FullTrigger>> triggersByTenant = new HashMap<>();
+
+    @Inject
+    /*
+     * This channel is already used in NotificationActionPluginListener. Because of that, the
+     * mp.messaging.outgoing.webhook.merge config key is required in applications.properties.
+     */
+    @Channel(WEBHOOK_CHANNEL)
+    @OnOverflow(UNBOUNDED_BUFFER)
+    Emitter<String> emitter;
+
+    @Inject
+    PoliciesHistoryService policiesHistoryService;
+
+    @PostConstruct
+    void postConstruct() {
+        boolean enabled = ConfigProvider.getConfig().getOptionalValue(LIGHTWEIGHT_ENGINE_CONFIG_KEY, Boolean.class).orElse(false);
+        LOGGER.infof("Lightweight engine is %s", enabled ? "enabled" : "disabled");
+    }
+
+    @Override
+    public void loadTrigger(FullTrigger fullTrigger) {
+        LOGGER.debugf("Loading trigger %s", fullTrigger);
+        provideDefaultDampening(fullTrigger);
+        String tenantId = fullTrigger.getTrigger().getTenantId();
+        triggersByTenant.computeIfAbsent(tenantId, unused -> new HashMap<>()).put(fullTrigger.getTrigger().getId(), fullTrigger);
+    }
+
+    @Override
+    public void reloadTrigger(Trigger trigger, Collection<Condition> conditions) {
+        LOGGER.debugf("Reloading trigger %s with conditions %s", trigger, conditions);
+        boolean found = false;
+        Map<String, FullTrigger> tenantTriggers = triggersByTenant.get(trigger.getTenantId());
+        if (tenantTriggers != null) {
+            FullTrigger fullTrigger = tenantTriggers.get(trigger.getId());
+            if (fullTrigger != null) {
+                fullTrigger.setTrigger(trigger);
+                fullTrigger.setConditions(new ArrayList<>(conditions));
+                found = true;
+                LOGGER.debugf("Trigger reloaded");
+            }
+        }
+        if (!found) {
+            LOGGER.debugf("Trigger to reload not found");
+        }
+    }
+
+    @Override
+    public void removeTrigger(String tenantId, String triggerId) {
+        LOGGER.debugf("Removing trigger %s/%s", tenantId, triggerId);
+        boolean found = false;
+        Map<String, FullTrigger> tenantTriggers = triggersByTenant.get(tenantId);
+        if (tenantTriggers != null) {
+            found = tenantTriggers.remove(triggerId) != null;
+            LOGGER.debugf("Trigger removed");
+        }
+        if (!found) {
+            LOGGER.debugf("Trigger to remove not found");
+        }
+    }
+
+    @Override
+    public void process(Event event) {
+        LOGGER.debugf("Processing event %s", event);
+        Set<Alert> alerts = fireTriggers(event);
+        if (alerts.isEmpty()) {
+            LOGGER.debug("No alerts created from the event");
+        } else {
+            LOGGER.debugf("%d alerts created from the event", alerts.size());
+
+            // In the old implementation, the time comes from the Action constructor which relies on System.currentTimeMillis().
+            LocalDateTime nowUTC = LocalDateTime.ofInstant(Instant.ofEpochMilli(System.currentTimeMillis()), UTC);
+
+            PoliciesAction policiesAction = new PoliciesAction();
+            policiesAction.setAccountId(event.getTenantId());
+            policiesAction.setTimestamp(nowUTC);
+
+            PoliciesAction.Context context = policiesAction.getContext();
+
+            for (Alert alert : alerts) {
+
+                // Tags from all alerts are merged into the policies action context tags.
+                for (Map.Entry<String, String> tagEntry : alert.getTags().entries()) {
+                    String tagValue = tagEntry.getValue();
+                    if (tagValue == null) {
+                        // Same behavior as previously with JsonObjectNoNullSerializer with old hooks
+                        tagValue = "";
+                    }
+                    context.getTags().computeIfAbsent(tagEntry.getKey(), unused -> new HashSet<>()).add(tagValue);
+                }
+
+                // Each alert is added to the policies action as an event.
+                for (Set<ConditionEval> evalSet : alert.getEvalSets()) {
+                    for (ConditionEval conditionEval : evalSet) {
+                        if (conditionEval instanceof EventConditionEval) {
+                            EventConditionEval eventEval = (EventConditionEval) conditionEval;
+
+                            if (context.getSystemCheckIn() == null) {
+                                context.setSystemCheckIn(LocalDateTime.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(eventEval.getContext().get("check_in"))));
+                            }
+                            if (context.getInventoryId() == null) {
+                                context.setInventoryId(eventEval.getContext().get("inventory_id"));
+                            }
+                            if (context.getDisplayName() == null) {
+                                context.setDisplayName(eventEval.getValue().getTags().get("display_name").iterator().next());
+                            }
+
+                            PoliciesAction.Event policiesEvent = new PoliciesAction.Event();
+                            policiesEvent.getPayload().setPolicyCondition(eventEval.getCondition().getExpression());
+                            policiesEvent.getPayload().setPolicyId(alert.getTrigger().getId());
+                            policiesEvent.getPayload().setPolicyName(alert.getTrigger().getName());
+                            policiesEvent.getPayload().setPolicyDescription(alert.getTrigger().getDescription());
+
+                            policiesAction.getEvents().add(policiesEvent);
+                            break;
+                        } else {
+                            LOGGER.warnf("Unsupported condition eval type %s", conditionEval);
+                        }
+                    }
+                }
+            }
+
+            try {
+                String payload = serializeAction(policiesAction);
+                LOGGER.debugf("Sending Kafka payload %s", payload);
+                emitter.send(buildMessageWithId(payload));
+            } catch (IOException e) {
+                LOGGER.warnf("Failed to serialize action for accountId", policiesAction.getAccountId());
+            }
+        }
+    }
+
+    /*
+     * Java equivalent of the old ProvideDefaultDampening rule.
+     * See the ConditionMatch.drl file for more details about that rule.
+     */
+    private void provideDefaultDampening(FullTrigger fullTrigger) {
+        if (fullTrigger.getDampenings().isEmpty()) {
+            Trigger trigger = fullTrigger.getTrigger();
+            LOGGER.debugf("Adding default %s dampening for trigger! %s", trigger.getMode(), trigger.getId());
+            Dampening dampening = Dampening.forStrict(trigger.getTenantId(), trigger.getId(), trigger.getMode(), 1 );
+            fullTrigger.getDampenings().add(dampening);
+        } else if (fullTrigger.getDampenings().size() > 1) {
+            // This should never be logged.
+            LOGGER.warnf("Trigger with more than one dampening found: %s", fullTrigger);
+        }
+    }
+
+    /*
+     * Returns alerts created from the fired triggers.
+     * This is kind of the Java equivalent of the old AlertOnSatisfiedDampening rule.
+     * See the ConditionMatch.drl file for more details about that rule.
+     */
+    private Set<Alert> fireTriggers(Event event) {
+        Map<String, FullTrigger> tenantTriggers = triggersByTenant.get(event.getTenantId());
+        if (tenantTriggers == null) {
+            LOGGER.debugf("No triggers found for tenant %s", event.getTenantId());
+            return Collections.emptySet();
+        } else {
+            LOGGER.debugf("Found %d triggers for tenant %s", tenantTriggers.size(), event.getTenantId());
+            Set<Alert> alerts = new HashSet<>();
+            for (FullTrigger fullTrigger : tenantTriggers.values()) {
+                LOGGER.debugf("Starting the trigger conditions evaluation");
+                Set<ConditionEval> conditionEvals = new HashSet<>();
+                for (Condition condition : fullTrigger.getConditions()) {
+                    switch (condition.getType()) {
+                        case EVENT:
+                            evaluateCondition(fullTrigger.getTrigger(), (EventCondition) condition, event).ifPresent(conditionEvals::add);
+                            break;
+                        default:
+                            LOGGER.warnf("Unsupported condition type %s", condition);
+                            break;
+                    }
+                }
+                // The trigger should always have exactly one dampening.
+                Dampening dampening = fullTrigger.getDampenings().get(0);
+                performDampening(dampening, fullTrigger.getTrigger(), conditionEvals);
+                if (dampening.isSatisfied()) {
+                    LOGGER.debugf("Dampening satisfied");
+                    Alert alert = new Alert(event.getTenantId(), fullTrigger.getTrigger(), dampening, dampening.getSatisfyingEvals());
+                    policiesHistoryService.put(alert);
+                    alerts.add(alert);
+                } else {
+                    LOGGER.debugf("Dampening not satisfied");
+                }
+                dampening.reset();
+            }
+            return alerts;
+        }
+    }
+
+    /*
+     * Java equivalent of the old Event rule.
+     * See the ConditionMatch.drl file for more details about that rule.
+     */
+    private Optional<EventConditionEval> evaluateCondition(Trigger trigger, EventCondition eventCondition, Event event) {
+        if (trigger.getMode() == eventCondition.getTriggerMode() && trigger.getSource().equals(event.getDataSource())
+                && eventCondition.getDataId().equals(event.getDataId())) {
+            EventConditionEval eval = new EventConditionEval(eventCondition, event);
+            LOGGER.debugf("Event Eval: %s %s", eval.isMatch() ? "Match!" : "no match", eval.getDisplayString());
+            return Optional.of(eval);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /*
+     * Java equivalent of the old DampenTrigger rule.
+     * See the ConditionMatch.drl file for more details about that rule.
+     */
+    private void performDampening(Dampening dampening, Trigger trigger, Set<ConditionEval> conditionEvals) {
+        LOGGER.debugf("Performing dampening of trigger %s", trigger);
+        dampening.perform(trigger.getMatch(), conditionEvals);
+    }
+}

--- a/external/src/main/java/com/redhat/cloud/policies/engine/actions/plugins/NotificationActionPluginListener.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/actions/plugins/NotificationActionPluginListener.java
@@ -168,7 +168,7 @@ public class NotificationActionPluginListener implements ActionPluginListener {
         return defaultProperties;
     }
 
-    private String serializeAction(PoliciesAction policiesAction) throws IOException {
+    public static String serializeAction(PoliciesAction policiesAction) throws IOException {
 
         Context.ContextBuilder contextBuilder = new Context.ContextBuilder();
         Map<String, Object> context = JsonObject.mapFrom(policiesAction.getContext()).getMap();
@@ -197,7 +197,7 @@ public class NotificationActionPluginListener implements ActionPluginListener {
         return Parser.encode(action);
     }
 
-    private static Message buildMessageWithId(String payload) {
+    public static Message buildMessageWithId(String payload) {
         byte[] messageId = UUID.randomUUID().toString().getBytes(UTF_8);
         OutgoingKafkaRecordMetadata metadata = OutgoingKafkaRecordMetadata.builder()
                 .withHeaders(new RecordHeaders().add(MESSAGE_ID_HEADER, messageId))

--- a/external/src/main/java/org/hawkular/alerts/AlertsStandalone.java
+++ b/external/src/main/java/org/hawkular/alerts/AlertsStandalone.java
@@ -5,6 +5,7 @@ import io.quarkus.runtime.LaunchMode;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.hawkular.alerts.api.services.ActionsService;
+import org.hawkular.alerts.api.services.LightweightEngine;
 import org.hawkular.alerts.api.services.PoliciesHistoryService;
 import org.hawkular.alerts.api.services.AlertsService;
 import org.hawkular.alerts.api.services.DefinitionsService;
@@ -56,6 +57,9 @@ public class AlertsStandalone {
 
     @Inject
     PoliciesHistoryService policiesHistoryService;
+
+    @Inject
+    LightweightEngine lightweightEngine;
 
     // The triggers' lifecycle is no longer used by policies-ui-backend. It has been replaced with a Postgres table.
     @ConfigProperty(name = "engine.triggers-lifecycle.disabled", defaultValue = "false")
@@ -165,6 +169,7 @@ public class AlertsStandalone {
     @PostConstruct
     void postConstruct() {
         ispnAlerts.setPoliciesHistoryService(policiesHistoryService);
+        engine.setLightweightEngine(lightweightEngine);
         if (triggersLifecycleDisabled) {
             log.info("Triggers lifecycle is disabled");
             engine.disableTriggersLifecycle();

--- a/external/src/main/resources/application.properties
+++ b/external/src/main/resources/application.properties
@@ -153,6 +153,6 @@ engine.triggers-lifecycle.disabled=true
 engine.actions-store.disabled=true
 
 # Enables LightweightEngine which is an engine implementation that does not rely on Infinispan or Drools.
-lightweight-engine.enabled=true
+lightweight-engine.enabled=false
 
 %test.quarkus.log.category."com.redhat.cloud.policies.engine.LightweightEngineImpl".level=DEBUG

--- a/external/src/main/resources/application.properties
+++ b/external/src/main/resources/application.properties
@@ -52,6 +52,8 @@ mp.messaging.outgoing.webhook.group.id=correlation
 mp.messaging.outgoing.webhook.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.outgoing.webhook.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.outgoing.webhook.max-inflight-messages=20
+# TODO POL-649 Remove the following config key when NotificationActionPluginListener is gone.
+mp.messaging.outgoing.webhook.merge=true
 
 # == Inbound properties
 engine.receiver.store-events=false
@@ -149,3 +151,8 @@ quarkus.http.non-application-root-path=/
 
 engine.triggers-lifecycle.disabled=true
 engine.actions-store.disabled=true
+
+# Enables LightweightEngine which is an engine implementation that does not rely on Infinispan or Drools.
+lightweight-engine.enabled=true
+
+%test.quarkus.log.category."com.redhat.cloud.policies.engine.LightweightEngineImpl".level=DEBUG

--- a/external/src/test/java/com/redhat/cloud/policies/engine/process/ReceiverTest.java
+++ b/external/src/test/java/com/redhat/cloud/policies/engine/process/ReceiverTest.java
@@ -204,7 +204,8 @@ public class ReceiverTest {
         Page<Alert> alerts = alertsService.getAlerts(TENANT_ID, criteria, null);
 
         // 4, because we have two triggers and we send the correct input twice
-        assertEquals(4, alerts.size());
+        // This assertion no longer works with LightweightEngine because alerts are no longer known to Hawkular.
+        //assertEquals(4, alerts.size());
 
         definitionsService.removeTrigger(TENANT_ID, TRIGGER_ID + "2");
     }


### PR DESCRIPTION
This PR is the first step of the removal of Infinispan, Drools and most of Hawkular from `policies-engine`. This step is only focused on making the Kafka messages processing simpler.

:information_source: If the `lightweight-engine.enabled` config key is set to `false` (which will be the default value), this PR does not have any impact on prod and can be merged safely.

Now, let's talk about what's changed :smiley: 

:arrow_forward: **BEFORE**

![before](https://user-images.githubusercontent.com/10584698/166463882-e2a8e5fd-7ce6-4fce-b7d1-f3d281d75070.png)

:arrow_forward: **AFTER**

![after](https://user-images.githubusercontent.com/10584698/166471608-4f21e810-0a57-415e-b044-e8897fb173ee.png)

:arrow_forward: **Important details**

- All triggers are loaded in memory (in a `HashMap`). This should be equivalent to what we had before since the triggers were loaded in memory through Drools. However, we will have to monitor the heap for a while to make sure everything's fine.
- The old logic based on a `TimerTask` (scheduled batch events processing) is gone. Now, whenever a Kafka message is received on the `platform.inventory.events` topic, the tenant's triggers conditions are immediately tested and if they are satisfied, a Kafka message is immediately sent to the `platform.notifications.ingress` topic.
- Hawkular includes features to limit alerts spam. For example, it can enforce a minimum delay between two events and discard events that do not comply with that policy. This is gone as well. The new engine will process any incoming message and transform it into an outgoing notification if one or several triggers of the tenant are fired.

:arrow_forward: **Next step**

Stop using Infinispan to store triggers and replace it with Postgres.