### PR TITLE
POL-649 Load trigger on reloading failure

### DIFF
--- a/external/src/main/java/com/redhat/cloud/policies/engine/LightweightEngineImpl.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/LightweightEngineImpl.java
@@ -91,7 +91,11 @@ public class LightweightEngineImpl implements LightweightEngine {
             }
         }
         if (!found) {
-            LOGGER.debugf("Trigger to reload not found");
+            LOGGER.debugf("Trigger to reload not found, forwarding the call to the loadTrigger method");
+            FullTrigger fullTrigger = new FullTrigger();
+            fullTrigger.setTrigger(trigger);
+            fullTrigger.setConditions(new ArrayList<>(conditions));
+            loadTrigger(fullTrigger);
         }
     }
 


### PR DESCRIPTION
Surprisingly, existing triggers are `reloaded` instead of `loaded` when the engine starts on stage.