### PR TITLE
POL-649 Support concurrency in LightweightEngineImpl triggers map

### DIFF
--- a/external/src/main/java/com/redhat/cloud/policies/engine/LightweightEngineImpl.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/LightweightEngineImpl.java
@@ -30,11 +30,11 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.redhat.cloud.policies.engine.actions.plugins.NotificationActionPluginListener.WEBHOOK_CHANNEL;
 import static com.redhat.cloud.policies.engine.actions.plugins.NotificationActionPluginListener.buildMessageWithId;
@@ -50,7 +50,7 @@ public class LightweightEngineImpl implements LightweightEngine {
     private static final Logger LOGGER = Logger.getLogger(LightweightEngineImpl.class);
 
     // The key of the outer map is the tenantId. The key of the inner map is the triggerId.
-    private final Map<String, Map<String, FullTrigger>> triggersByTenant = new HashMap<>();
+    private final Map<String, Map<String, FullTrigger>> triggersByTenant = new ConcurrentHashMap<>();
 
     @Inject
     /*
@@ -83,7 +83,7 @@ public class LightweightEngineImpl implements LightweightEngine {
         LOGGER.debugf("Loading trigger %s", fullTrigger);
         provideDefaultDampening(fullTrigger);
         String tenantId = fullTrigger.getTrigger().getTenantId();
-        triggersByTenant.computeIfAbsent(tenantId, unused -> new HashMap<>()).put(fullTrigger.getTrigger().getId(), fullTrigger);
+        triggersByTenant.computeIfAbsent(tenantId, unused -> new ConcurrentHashMap<>()).put(fullTrigger.getTrigger().getId(), fullTrigger);
     }
 
     @Override


### PR DESCRIPTION
Fixes
```
2022-05-04 07:14:24,807 ERROR [io.sma.rea.mes.provider] (vert.x-eventloop-thread-0) SRMSG00201: Error caught while processing a message: java.util.ConcurrentModificationException
	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1511)
	at java.base/java.util.HashMap$ValueIterator.next(HashMap.java:1539)
	at com.redhat.cloud.policies.engine.LightweightEngineImpl.fireTriggers(LightweightEngineImpl.java:230)
	at com.redhat.cloud.policies.engine.LightweightEngineImpl.process(LightweightEngineImpl.java:131)
	at com.redhat.cloud.policies.engine.LightweightEngineImpl_ClientProxy.process(Unknown Source)
	at com.redhat.cloud.policies.engine.process.Receiver.processAsync(Receiver.java:197)
	at com.redhat.cloud.policies.engine.process.Receiver_ClientProxy.processAsync(Unknown Source)
	at com.redhat.cloud.policies.engine.process.Receiver_SmallRyeMessagingInvoker_processAsync_6c5b0d269fa034a5e2c78aed9e5e02cf041553e0.invoke(Unknown Source)
	at io.smallrye.reactive.messaging.providers.AbstractMediator.lambda$invokeBlocking$4(AbstractMediator.java:116)
	at io.smallrye.context.impl.wrappers.SlowContextualConsumer.accept(SlowContextualConsumer.java:21)
	at io.smallrye.mutiny.operators.uni.builders.UniCreateWithEmitter.subscribe(UniCreateWithEmitter.java:22)
	at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:36)
	at io.smallrye.mutiny.operators.uni.builders.UniCreateFromDeferredSupplier.subscribe(UniCreateFromDeferredSupplier.java:36)
	at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:36)
	at io.smallrye.mutiny.groups.UniSubscribe.withSubscriber(UniSubscribe.java:52)
	at io.smallrye.mutiny.groups.UniSubscribe.with(UniSubscribe.java:112)
	at io.smallrye.mutiny.groups.UniSubscribe.with(UniSubscribe.java:89)
	at io.vertx.mutiny.core.Context$1.handle(Context.java:170)
	at io.vertx.mutiny.core.Context$1.handle(Context.java:168)
	at io.vertx.core.impl.ContextImpl.lambda$null$0(ContextImpl.java:159)
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:100)
	at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$1(ContextImpl.java:157)
	at io.vertx.core.impl.TaskQueue.run(TaskQueue.java:76)
	at io.quarkus.vertx.core.runtime.VertxCoreRecorder$14.runWith(VertxCoreRecorder.java:548)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2449)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1478)
	at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:29)
	at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:29)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
```