### PR TITLE
POL-649 Remove duplicate LightweightEngine call

### DIFF
--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
@@ -451,9 +451,6 @@ public class AlertsEngineImpl implements AlertsEngine, PartitionTriggerListener,
         } else {
             removeTrigger(triggerToRemove);
         }
-        if (lightweightEngine != null) {
-            lightweightEngine.removeTrigger(triggerToRemove.getTenantId(), triggerToRemove.getId());
-        }
     }
 
     private void removeTrigger(Trigger trigger) {


### PR DESCRIPTION
#373 fixed a bug but also added a duplicate `LightweightEngine#removeTrigger` call when a trigger is deleted. This PR removes the duplicate.