### PR TITLE
POL-649 Return condition validation error in REST response

### DIFF
--- a/api/src/main/java/org/hawkular/alerts/api/services/LightweightEngine.java
+++ b/api/src/main/java/org/hawkular/alerts/api/services/LightweightEngine.java
@@ -15,7 +15,7 @@ public interface LightweightEngine {
     /**
      * Validates a policy condition.
      * @param condition the condition to validate
-     * @throws javax.ws.rs.BadRequestException if the condition is not valid
+     * @throws IllegalArgumentException if the condition is not valid
      */
     void validateCondition(String condition);
 

--- a/external/src/main/java/com/redhat/cloud/policies/engine/lightweight/LightweightEngineImpl.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/lightweight/LightweightEngineImpl.java
@@ -23,7 +23,6 @@ import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import javax.ws.rs.BadRequestException;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -80,12 +79,7 @@ public class LightweightEngineImpl implements LightweightEngine {
     @Override
     public void validateCondition(String condition) {
         if (lightweightEngineConfig.isDbLoadingEnabled()) {
-            try {
-                ExprParser.validate(condition);
-            } catch (Exception e) {
-                LOGGER.debugf(e, "Validation failed for condition %s", condition);
-                throw new BadRequestException(e.getMessage());
-            }
+            ExprParser.validate(condition);
         } else {
             LOGGER.debug("Ignoring validateCondition call because the lightweight engine DB loading is disabled");
         }

--- a/external/src/main/java/com/redhat/cloud/policies/engine/lightweight/LightweightEngineResource.java
+++ b/external/src/main/java/com/redhat/cloud/policies/engine/lightweight/LightweightEngineResource.java
@@ -1,17 +1,25 @@
 package com.redhat.cloud.policies.engine.lightweight;
 
+import io.vertx.core.json.JsonObject;
 import org.hawkular.alerts.api.services.LightweightEngine;
+import org.jboss.logging.Logger;
 
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import java.util.Map;
 
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 
 @Path("/lightweight-engine")
 public class LightweightEngineResource {
+
+    private static final Logger LOGGER = Logger.getLogger(LightweightEngineResource.class);
 
     @Inject
     LightweightEngine lightweightEngine;
@@ -19,7 +27,14 @@ public class LightweightEngineResource {
     @PUT
     @Path("/validate")
     @Consumes(TEXT_PLAIN)
-    public void validateCondition(@NotNull String condition) {
-        lightweightEngine.validateCondition(condition);
+    public Response validateCondition(@NotNull String condition) {
+        try {
+            lightweightEngine.validateCondition(condition);
+            return Response.ok().build();
+        } catch (Exception e) {
+            LOGGER.debugf(e, "Validation failed for condition %s", condition);
+            JsonObject errorMessage = new JsonObject(Map.of("errorMsg", e.getMessage()));
+            return Response.status(BAD_REQUEST).entity(errorMessage).build();
+        }
     }
 }


### PR DESCRIPTION
Related to https://github.com/RedHatInsights/policies-ui-backend/pull/426.

When an invalid condition is validated on stage with the lightweight engine, the validation error message isn't forwarded to the browser. This is the first half of the fix.