### PR TITLE
POL-649 Add clowder-quarkus-config-source in external module

### DIFF
--- a/external/pom.xml
+++ b/external/pom.xml
@@ -97,6 +97,13 @@
       <artifactId>quarkus-logging-cloudwatch</artifactId>
     </dependency>
 
+    <!-- Configuration -->
+    <dependency>
+      <groupId>com.redhat.cloud.common</groupId>
+      <artifactId>clowder-quarkus-config-source</artifactId>
+      <version>${clowder-quarkus-config-source.version}</version>
+    </dependency>
+
     <!-- Tests -->
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
That dependency was previously declared in the pom.xml from the `engine` module which has been completely removed from the project.