### PR TITLE
POL-649 Fix memory limit to request ratio

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -114,7 +114,7 @@ parameters:
   value: INFO
 - name: MEMORY_LIMIT
   description: Memory limit
-  value: 1Gi
+  value: 1000Mi
 - name: MEMORY_REQUEST
   description: Memory request
   value: 500Mi


### PR DESCRIPTION
Fixes
```
Error creating: pods "policies-engine-service-5998fd7cff-w8rsw" is forbidden: memory max limit to request ratio per Container is 2, but provided ratio is 2.048000
```