### PR TITLE
Use the new Quarkus Log API

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/engine/RunOnStartup.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/RunOnStartup.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.policies.engine;
 
+import io.quarkus.logging.Log;
 import io.quarkus.runtime.Startup;
 import java.io.BufferedReader;
 import java.io.InputStream;
@@ -8,15 +9,12 @@ import java.util.regex.Pattern;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import javax.annotation.PostConstruct;
-import org.jboss.logging.Logger;
 
 @Startup
 public class RunOnStartup {
 
     // TODO POL-649 Update that pattern after the new health check call has been confirmed.
     public static final Pattern ACCESS_LOG_FILTER_PATTERN = Pattern.compile(".*(/health(/\\w+)?|/metrics|/hawkular/alerts/triggers\\?triggerIds=dummy) HTTP/[0-9].[0-9]\" 200.*\\n?");
-
-    private static final Logger LOGGER = Logger.getLogger(RunOnStartup.class);
 
     @ConfigProperty(name = "quarkus.http.access-log.category")
     String accessLogCategory;
@@ -47,10 +45,10 @@ public class RunOnStartup {
                         }
                     }
                 }
-                LOGGER.info(result.toString());
+                Log.info(result.toString());
             }
         } catch (Exception e) {
-            LOGGER.error("Could not read git.properties", e);
+            Log.error("Could not read git.properties", e);
         }
     }
 }

--- a/src/main/java/com/redhat/cloud/policies/engine/clowder/KafkaSaslInitializer.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/clowder/KafkaSaslInitializer.java
@@ -1,9 +1,9 @@
 package com.redhat.cloud.policies.engine.clowder;
 
+import io.quarkus.logging.Log;
 import io.quarkus.runtime.StartupEvent;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.jboss.logging.Logger;
 
 import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
@@ -19,7 +19,6 @@ import static javax.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
 @ApplicationScoped
 public class KafkaSaslInitializer {
 
-    private static final Logger LOGGER = Logger.getLogger(KafkaSaslInitializer.class);
     private static final String KAFKA_SASL_JAAS_CONFIG = "kafka.sasl.jaas.config";
     private static final String KAFKA_SASL_MECHANISM = "kafka.sasl.mechanism";
     private static final String KAFKA_SECURITY_PROTOCOL = "kafka.security.protocol";
@@ -35,7 +34,7 @@ public class KafkaSaslInitializer {
         Optional<String> kafkaSslTruststoreType = config.getOptionalValue(KAFKA_SSL_TRUSTSTORE_TYPE, String.class);
 
         if (kafkaSaslJaasConfig.isPresent() || kafkaSaslMechanism.isPresent() || kafkaSecurityProtocol.isPresent() || kafkaSslTruststoreLocation.isPresent() || kafkaSslTruststoreType.isPresent()) {
-            LOGGER.info("Initializing Kafka SASL configuration...");
+            Log.info("Initializing Kafka SASL configuration...");
             setValue(KAFKA_SASL_JAAS_CONFIG, kafkaSaslJaasConfig);
             setValue(KAFKA_SASL_MECHANISM, kafkaSaslMechanism);
             setValue(KAFKA_SECURITY_PROTOCOL, kafkaSecurityProtocol);
@@ -47,7 +46,7 @@ public class KafkaSaslInitializer {
     private static void setValue(String configKey, Optional<String> configValue) {
         configValue.ifPresent(value -> {
             System.setProperty(configKey, value);
-            LOGGER.infof("%s has been set", configKey);
+            Log.infof("%s has been set", configKey);
         });
     }
 }

--- a/src/main/java/com/redhat/cloud/policies/engine/condition/ConditionParser.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/condition/ConditionParser.java
@@ -1,8 +1,6 @@
 package com.redhat.cloud.policies.engine.condition;
 
-import com.redhat.cloud.policies.engine.condition.ExpressionBaseVisitor;
-import com.redhat.cloud.policies.engine.condition.ExpressionLexer;
-import com.redhat.cloud.policies.engine.condition.ExpressionParser;
+import io.quarkus.logging.Log;
 import org.antlr.v4.runtime.ANTLRErrorListener;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
@@ -20,7 +18,6 @@ import java.math.BigDecimal;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.Map;
-import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 public class ConditionParser extends ExpressionBaseVisitor<Boolean> {
@@ -34,8 +31,6 @@ public class ConditionParser extends ExpressionBaseVisitor<Boolean> {
 
     private static final Pattern KEY_REGEXP = Pattern.compile("(?<!\\\\)\\.");
     private static final Pattern ESCAPE_CLEANER_REGEXP = Pattern.compile("^(['\"])(.*)\\1$");
-
-    private static final Logger log = Logger.getLogger("ExpParser");
 
     static ParseTree createParserTree(String expression, ANTLRErrorListener errorListener) {
         CharStream cs = CharStreams.fromString(expression);
@@ -203,7 +198,7 @@ public class ConditionParser extends ExpressionBaseVisitor<Boolean> {
                     }
                 }
             } catch(NumberFormatException e) {
-                log.warning("Failed to parse value into a number " + e.getMessage());
+                Log.warn("Failed to parse value into a number " + e.getMessage());
                 return false;
             }
 

--- a/src/main/java/com/redhat/cloud/policies/engine/db/StatelessSessionFactory.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/db/StatelessSessionFactory.java
@@ -1,8 +1,8 @@
 package com.redhat.cloud.policies.engine.db;
 
+import io.quarkus.logging.Log;
 import org.hibernate.Session;
 import org.hibernate.StatelessSession;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -12,8 +12,6 @@ import java.util.function.Function;
 
 @ApplicationScoped
 public class StatelessSessionFactory {
-
-    private static final Logger LOGGER = Logger.getLogger(StatelessSessionFactory.class);
 
     @Inject
     EntityManager entityManager;
@@ -71,7 +69,7 @@ public class StatelessSessionFactory {
         if (threadLocalSession.get() != null) {
             throw new IllegalStateException("Stateless session already bound to the current thread. Did you use nested StatelessSessionFactory#withSession calls?");
         } else {
-            LOGGER.trace("Creating a new stateless session");
+            Log.trace("Creating a new stateless session");
             StatelessSession session = entityManager.unwrap(Session.class).getSessionFactory().openStatelessSession();
             /*
              * We're not using ThreadLocal#withInitial because StatelessSessionFactory#close needs to call ThreadLocal#get
@@ -86,10 +84,10 @@ public class StatelessSessionFactory {
         StatelessSession session = threadLocalSession.get();
         if (session != null) {
             if (session.isOpen()) {
-                LOGGER.trace("Closing the current stateless session");
+                Log.trace("Closing the current stateless session");
                 session.close();
             }
-            LOGGER.trace("Removing the current stateless session from ThreadLocal field");
+            Log.trace("Removing the current stateless session from ThreadLocal field");
             threadLocalSession.remove();
         }
     }

--- a/src/main/java/com/redhat/cloud/policies/engine/db/repositories/PoliciesHistoryRepository.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/db/repositories/PoliciesHistoryRepository.java
@@ -3,7 +3,7 @@ package com.redhat.cloud.policies.engine.db.repositories;
 import com.redhat.cloud.policies.engine.db.StatelessSessionFactory;
 import com.redhat.cloud.policies.engine.db.entities.PoliciesHistoryEntry;
 import com.redhat.cloud.policies.engine.process.Event;
-import org.jboss.logging.Logger;
+import io.quarkus.logging.Log;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -16,8 +16,6 @@ import static com.redhat.cloud.policies.engine.process.PayloadParser.INVENTORY_I
 
 @ApplicationScoped
 public class PoliciesHistoryRepository {
-
-    private static final Logger LOGGER = Logger.getLogger(PoliciesHistoryRepository.class);
 
     @Inject
     StatelessSessionFactory statelessSessionFactory;
@@ -32,9 +30,9 @@ public class PoliciesHistoryRepository {
             getSingleTagValue(event, INVENTORY_ID_FIELD).ifPresent(historyEntry::setHostId);
             getSingleTagValue(event, DISPLAY_NAME_FIELD).ifPresent(historyEntry::setHostName);
             statelessSessionFactory.getCurrentSession().insert(historyEntry);
-            LOGGER.debugf("Created %s", historyEntry);
+            Log.debugf("Created %s", historyEntry);
         } catch (Exception e) {
-            LOGGER.error("Policies history entry creation failed", e);
+            Log.error("Policies history entry creation failed", e);
         }
     }
 

--- a/src/main/java/com/redhat/cloud/policies/engine/metrics/ProcSelfStatusExporter.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/metrics/ProcSelfStatusExporter.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.policies.engine.metrics;
 
+import io.quarkus.logging.Log;
 import io.quarkus.scheduler.Scheduled;
 import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
@@ -7,7 +8,6 @@ import org.eclipse.microprofile.metrics.annotation.Gauge;
 import javax.enterprise.context.ApplicationScoped;
 import java.io.File;
 import java.util.Scanner;
-import java.util.logging.Logger;
 
 
 /**
@@ -26,8 +26,6 @@ import java.util.logging.Logger;
  */
 @ApplicationScoped
 public class ProcSelfStatusExporter {
-
-    private final Logger log = Logger.getLogger(this.getClass().getSimpleName());
 
     private static final String PATHNAME = "/proc/self/status";
 
@@ -48,7 +46,7 @@ public class ProcSelfStatusExporter {
         File status = new File(PATHNAME);
         if (!status.exists() || !status.canRead()) {
             if (!hasWarned) {
-                log.warning("Can't read " + PATHNAME);
+                Log.warn("Can't read " + PATHNAME);
                 hasWarned = true;
             }
             return;
@@ -92,7 +90,7 @@ public class ProcSelfStatusExporter {
                 }
             }
         } catch (Exception e) {
-            log.warning("Scanning of file failed: " + e.getMessage());
+            Log.warn("Scanning of file failed: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/redhat/cloud/policies/engine/process/NotificationSender.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/process/NotificationSender.java
@@ -5,6 +5,7 @@ import com.redhat.cloud.notifications.ingress.Context;
 import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Parser;
 import com.redhat.cloud.notifications.ingress.Payload;
+import io.quarkus.logging.Log;
 import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
 import io.vertx.core.json.JsonObject;
 import org.apache.kafka.common.header.internals.RecordHeaders;
@@ -14,7 +15,6 @@ import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.OnOverflow;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -34,8 +34,6 @@ public class NotificationSender {
     public static final String APP_NAME = "policies";
     public static final String EVENT_TYPE_NAME = "policy-triggered";
 
-    private static final Logger LOGGER = Logger.getLogger(NotificationSender.class);
-
     @Inject
     @Channel(WEBHOOK_CHANNEL)
     @OnOverflow(UNBOUNDED_BUFFER)
@@ -47,7 +45,7 @@ public class NotificationSender {
 
     public void send(PoliciesAction policiesAction) {
         String payload = serializeAction(policiesAction);
-        LOGGER.debugf("Sending Kafka payload %s", payload);
+        Log.debugf("Sending Kafka payload %s", payload);
         Message<String> message = buildMessageWithId(payload);
         emitter.send(message);
         notificationsCounter.inc();

--- a/src/main/java/com/redhat/cloud/policies/engine/process/PayloadParser.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/process/PayloadParser.java
@@ -2,11 +2,11 @@ package com.redhat.cloud.policies.engine.process;
 
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
+import io.quarkus.logging.Log;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.annotation.Metric;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -29,7 +29,6 @@ public class PayloadParser {
     public static final String NETWORK_INTERFACES_FIELD = "network_interfaces";
     public static final String YUM_REPOS_FIELD = "yum_repos";
 
-    private static final Logger LOGGER = Logger.getLogger(PayloadParser.class);
     private static final Set<String> ACCEPTED_REPORTERS = Set.of("puptoo");
     private static final Set<String> ACCEPTED_TYPES = Set.of("created", "updated");
     private static final String TYPE_FIELD = "type";
@@ -84,7 +83,7 @@ public class PayloadParser {
         if (json.containsKey(TYPE_FIELD)) {
             String eventType = json.getString(TYPE_FIELD);
             if(!ACCEPTED_TYPES.contains(eventType)) {
-                LOGGER.debugf("Got a request with type='%s', ignoring ", eventType);
+                Log.debugf("Got a request with type='%s', ignoring ", eventType);
                 rejectedCount.inc();
                 rejectedCountType.inc();
                 return Optional.empty();

--- a/src/main/java/com/redhat/cloud/policies/engine/process/Receiver.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/process/Receiver.java
@@ -1,9 +1,9 @@
 package com.redhat.cloud.policies.engine.process;
 
 import com.redhat.cloud.policies.engine.db.StatelessSessionFactory;
+import io.quarkus.logging.Log;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -17,8 +17,6 @@ public class Receiver {
 
     public static final String EVENTS_CHANNEL = "events";
 
-    private static final Logger LOGGER = Logger.getLogger(Receiver.class);
-
     @Inject
     PayloadParser payloadParser;
 
@@ -31,7 +29,7 @@ public class Receiver {
     @Incoming(EVENTS_CHANNEL)
     @Blocking
     public void process(String payload) {
-        LOGGER.tracef("Received payload: %s", payload);
+        Log.tracef("Received payload: %s", payload);
         payloadParser.parse(payload).ifPresent(event -> {
             statelessSessionFactory.withSession(statelessSession -> {
                 eventProcessor.process(event);

--- a/src/main/java/com/redhat/cloud/policies/engine/rest/LightweightEngineResource.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/rest/LightweightEngineResource.java
@@ -1,8 +1,8 @@
 package com.redhat.cloud.policies.engine.rest;
 
 import com.redhat.cloud.policies.engine.condition.ConditionParser;
+import io.quarkus.logging.Log;
 import io.vertx.core.json.JsonObject;
-import org.jboss.logging.Logger;
 
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -18,8 +18,6 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 @Path("/lightweight-engine")
 public class LightweightEngineResource {
 
-    private static final Logger LOGGER = Logger.getLogger(LightweightEngineResource.class);
-
     @PUT
     @Path("/validate")
     @Consumes(TEXT_PLAIN)
@@ -28,7 +26,7 @@ public class LightweightEngineResource {
             ConditionParser.validate(condition);
             return Response.ok().build();
         } catch (Exception e) {
-            LOGGER.debugf(e, "Validation failed for condition %s", condition);
+            Log.debugf(e, "Validation failed for condition %s", condition);
             JsonObject errorMessage = new JsonObject(Map.of("errorMsg", e.getMessage()));
             return Response.status(BAD_REQUEST).entity(errorMessage).build();
         }


### PR DESCRIPTION
Quarkus recently introduced a new `Log` API which delegates all its invocations to `org.jboss.logging.Logger`. Building the logger is no longer needed.