### PR TITLE
Improve log messages related to orgId

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/engine/db/entities/PoliciesHistoryEntry.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/db/entities/PoliciesHistoryEntry.java
@@ -102,6 +102,6 @@ public class PoliciesHistoryEntry {
 
     @Override
     public String toString() {
-        return "PoliciesHistoryEntry [id=" + id + ", tenantId=" + tenantId + ", policyId=" + policyId + ", ctime=" + ctime + ", hostId=" + hostId + ", hostName=" + hostName + "]";
+        return "PoliciesHistoryEntry [id=" + id + ", tenantId=" + tenantId + ", orgId=" + orgId + ", policyId=" + policyId + ", ctime=" + ctime + ", hostId=" + hostId + ", hostName=" + hostName + "]";
     }
 }

--- a/src/main/java/com/redhat/cloud/policies/engine/process/EventProcessor.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/process/EventProcessor.java
@@ -76,9 +76,17 @@ public class EventProcessor {
         }
 
         if (enabledPolicies.isEmpty()) {
-            Log.debugf("No enabled policies found for account (accountId: %s, orgId: %s)", event.getAccountId(), event.getOrgId());
+            if (orgIdConfig.isUseOrgId()) {
+                Log.debugf("No enabled policies found for orgId %s", event.getOrgId());
+            } else {
+                Log.debugf("No enabled policies found for accountId %s", event.getAccountId());
+            }
         } else {
-            Log.debugf("Found %d enabled policies for account (accountId: %s, orgId: %s)", enabledPolicies.size(), event.getAccountId(), event.getOrgId());
+            if (orgIdConfig.isUseOrgId()) {
+                Log.debugf("Found %d enabled policies for orgId %s", enabledPolicies.size(), event.getOrgId());
+            } else {
+                Log.debugf("Found %d enabled policies for accountId %s", enabledPolicies.size(), event.getAccountId());
+            }
 
             PoliciesAction policiesAction = new PoliciesAction();
             policiesAction.setOrgId(event.getOrgId());


### PR DESCRIPTION
I am monitoring `stage` with the `orgId` enabled. This will make some log entries clearer.