### PR TITLE
Prevent NPE in ConditionParser

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/engine/condition/ConditionParser.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/condition/ConditionParser.java
@@ -259,7 +259,9 @@ public class ConditionParser extends ExpressionBaseVisitor<Boolean> {
                     boolean validForAll = true;
                     for (ExpressionParser.ValueContext valueContext : ctx.array().value()) {
                         String val = valueToString(valueContext);
-                        validForAll &= targetValueStr.contains(val);
+                        if (val != null) {
+                            validForAll &= targetValueStr.contains(val);
+                        }
                     }
                     return validForAll;
                 }


### PR DESCRIPTION
This is an emergency fix for production.

Pods are crashlooping because of the following exception:
```
2023-02-14 10:44:47,076 ERROR [io.sma.rea.mes.provider] (vert.x-eventloop-thread-0) SRMSG00201: Error caught while processing a message in method com.redhat.cloud.policies.engine.process.Receiver#process: java.lang.NullPointerException
	at java.base/java.lang.String.contains(String.java:2036)
	at com.redhat.cloud.policies.engine.condition.ConditionParser$ExprVisitor.visitExpr(ConditionParser.java:262)
	at com.redhat.cloud.policies.engine.condition.ConditionParser$ExprVisitor.visitObject(ConditionParser.java:108)
	at com.redhat.cloud.policies.engine.condition.ConditionParser$ExprVisitor.visitExpression(ConditionParser.java:97)
	at com.redhat.cloud.policies.engine.condition.ConditionParser$ExprVisitor.visitExpression(ConditionParser.java:87)
	at com.redhat.cloud.policies.engine.condition.ExpressionParser$ExpressionContext.accept(ExpressionParser.java:123)
	at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visit(AbstractParseTreeVisitor.java:18)
	at com.redhat.cloud.policies.engine.condition.ConditionParser.evaluate(ConditionParser.java:58)
	at com.redhat.cloud.policies.engine.process.EventProcessor.isFired(EventProcessor.java:121)
	at com.redhat.cloud.policies.engine.process.EventProcessor.process(EventProcessor.java:92)
	at com.redhat.cloud.policies.engine.process.EventProcessor_ClientProxy.process(Unknown Source)
	at com.redhat.cloud.policies.engine.process.Receiver.lambda$process$0(Receiver.java:37)
	at com.redhat.cloud.policies.engine.db.StatelessSessionFactory.withSession(StatelessSessionFactory.java:31)
	at com.redhat.cloud.policies.engine.db.StatelessSessionFactory_ClientProxy.withSession(Unknown Source)
	at com.redhat.cloud.policies.engine.process.Receiver.lambda$process$1(Receiver.java:36)
	at java.base/java.util.Optional.ifPresent(Optional.java:183)
	at com.redhat.cloud.policies.engine.process.Receiver.process(Receiver.java:35)
	at com.redhat.cloud.policies.engine.process.Receiver_Subclass.process$$superforward1(Unknown Source)
	at com.redhat.cloud.policies.engine.process.Receiver_Subclass$$function$$1.apply(Unknown Source)
	at io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:54)
	at io.quarkus.arc.impl.ActivateRequestContextInterceptor.invoke(ActivateRequestContextInterceptor.java:129)
	at io.quarkus.arc.impl.ActivateRequestContextInterceptor.aroundInvoke(ActivateRequestContextInterceptor.java:33)
	at io.quarkus.arc.impl.ActivateRequestContextInterceptor_Bean.intercept(Unknown Source)
	at io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:42)
	at io.quarkus.arc.impl.AroundInvokeInvocationContext.perform(AroundInvokeInvocationContext.java:41)
	at io.quarkus.arc.impl.InvocationContexts.performAroundInvoke(InvocationContexts.java:33)
	at com.redhat.cloud.policies.engine.process.Receiver_Subclass.process(Unknown Source)
	at com.redhat.cloud.policies.engine.process.Receiver_ClientProxy.process(Unknown Source)
	at com.redhat.cloud.policies.engine.process.Receiver_SmallRyeMessagingInvoker_process_bd386abe989418e778612ad8212523c81d813d5e.invoke(Unknown Source)
	at io.smallrye.reactive.messaging.providers.AbstractMediator.lambda$invokeBlocking$4(AbstractMediator.java:125)
	at io.smallrye.context.impl.wrappers.SlowContextualConsumer.accept(SlowContextualConsumer.java:21)
	at io.smallrye.mutiny.operators.uni.builders.UniCreateWithEmitter.subscribe(UniCreateWithEmitter.java:22)
	at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:36)
	at io.smallrye.mutiny.operators.uni.builders.UniCreateFromDeferredSupplier.subscribe(UniCreateFromDeferredSupplier.java:36)
	at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:36)
	at io.smallrye.mutiny.groups.UniSubscribe.withSubscriber(UniSubscribe.java:52)
	at io.smallrye.mutiny.groups.UniSubscribe.with(UniSubscribe.java:112)
	at io.smallrye.mutiny.groups.UniSubscribe.with(UniSubscribe.java:89)
	at io.vertx.mutiny.core.Context$1.handle(Context.java:170)
	at io.vertx.mutiny.core.Context$1.handle(Context.java:168)
	at io.vertx.core.impl.ContextBase.lambda$null$0(ContextBase.java:137)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:264)
	at io.vertx.core.impl.ContextBase.lambda$executeBlocking$1(ContextBase.java:135)
	at io.vertx.core.impl.TaskQueue.run(TaskQueue.java:76)
	at io.quarkus.vertx.core.runtime.VertxCoreRecorder$14.runWith(VertxCoreRecorder.java:564)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2449)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1478)
	at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:29)
	at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:29)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
```