### PR TITLE
Create certs using kafka's java version

### DIFF
--- a/helpers/kafka-sasl-ssl/.env
+++ b/helpers/kafka-sasl-ssl/.env
@@ -1,0 +1,1 @@
+KAFKA_IMAGE=strimzi/kafka:0.20.1-kafka-2.5.0

--- a/helpers/kafka-sasl-ssl/.gitignore
+++ b/helpers/kafka-sasl-ssl/.gitignore
@@ -1,0 +1,2 @@
+/certs
+/cdappconfig.json

--- a/helpers/kafka-sasl-ssl/README.adoc
+++ b/helpers/kafka-sasl-ssl/README.adoc
@@ -14,12 +14,8 @@ docker-compose up
 .Start `policies-engine` - this command assumes you copied `cdappconfig.json` to the root of the project - passing the following environment variables.
 
 ```bash
-cd external;
 KAFKA_BOOTSTRAP_SERVERS="localhost:29092" \
-KAFKA_SECURITY_PROTOCOL="SSL" \
-KAFKA_SSL_TRUSTSTORE_LOCATION="`pwd`/../helpers/kafka-ssl/certs/ca/cacert.pem" \
-KAFKA_SSL_TRUSTSTORE_TYPE="PEM" \
 KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM="" \
 ACG_CONFIG="./cdappconfig.json" \
-mvn compile quarkus:dev
+./mvnw compile quarkus:dev
 ```

--- a/helpers/kafka-sasl-ssl/README.adoc
+++ b/helpers/kafka-sasl-ssl/README.adoc
@@ -1,0 +1,25 @@
+This folder contains files to help test the connection from `policies-engine` to a Kafka instance with SASL-SSL using SCRAM-SHA-512.
+
+## Usage
+
+. Start the docker-compose instance - This will take care of create certificates and configuring the users required.
+
+The default username and passwords are admin/admin-secret -  a `cdappconfig.json` file is created with the kafka configuration.
+Copy to the root of the project and update as needed for other configuration.
+
+```bash
+docker-compose up
+```
+
+.Start `policies-engine` - this command assumes you copied `cdappconfig.json` to the root of the project - passing the following environment variables.
+
+```bash
+cd external;
+KAFKA_BOOTSTRAP_SERVERS="localhost:29092" \
+KAFKA_SECURITY_PROTOCOL="SSL" \
+KAFKA_SSL_TRUSTSTORE_LOCATION="`pwd`/../helpers/kafka-ssl/certs/ca/cacert.pem" \
+KAFKA_SSL_TRUSTSTORE_TYPE="PEM" \
+KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM="" \
+ACG_CONFIG="./cdappconfig.json" \
+mvn compile quarkus:dev
+```

--- a/helpers/kafka-sasl-ssl/cdappconfig-template.json
+++ b/helpers/kafka-sasl-ssl/cdappconfig-template.json
@@ -1,0 +1,45 @@
+{
+  "database": {
+    "adminPassword": "postgres",
+    "adminUsername": "postgres",
+    "hostname": "localhost",
+    "name": "policies",
+    "password": "postgres",
+    "port": 5432,
+    "sslMode": "disable",
+    "username": "postgres"
+  },
+  "kafka": {
+    "brokers": [
+      {
+        "authtype": "sasl",
+        "hostname": "localhost",
+        "cacert": "",
+        "port": 29092,
+        "sasl": {
+          "password": "admin-secret",
+          "saslMechanism": "SCRAM-SHA-512",
+          "username": "admin",
+          "securityProtocol": "SASL_SSL"
+        },
+        "securityProtocol": "SASL_SSL"
+      }
+    ],
+    "topics": [
+      {
+        "name": "platform.inventory.events",
+        "requestedName": "platform.inventory.events"
+      },
+      {
+        "name": "platform.notifications.ingress",
+        "requestedName": "platform.notifications.ingress"
+      }
+    ]
+  },
+  "logging": {
+    "cloudwatch": {
+
+    }
+  },
+  "webPort": 8000
+}

--- a/helpers/kafka-sasl-ssl/create-certs.sh
+++ b/helpers/kafka-sasl-ssl/create-certs.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ -d "./certs" ]];
+then
+  echo "./certs exist - skipping creation"
+else
+
+  mkdir -p ./certs/server
+  mkdir -p ./certs/ca
+
+  KEYSTORE_PASSWORD="supersecure"
+  KEYSTORE_PATH="./certs/server/server-keystore.jks"
+  CA_CERT="./certs/ca/cacert.pem"
+  CA_KEY="./certs/ca/cakey.pem"
+  SIGNING_REQUEST="./certs/server/server.signing-request"
+  SIGNED_CERT="./certs/server/server.certificate"
+  KAFKA_HOSTNAME="localhost"
+
+  echo "Deleting previous cert/key (if found)"
+  rm -f "${KEYSTORE_PATH}" "${SIGNING_REQUEST}" "${CA_CERT}" "${CA_KEY}" "${SIGNED_CERT}" "./certs/ca/cacert.srl"
+
+  # Create server key store
+  keytool -keystore "${KEYSTORE_PATH}" -alias localhost -validity 1024 -genkey -keyalg RSA -storetype pkcs12 -noprompt \
+  -dname "CN=${KAFKA_HOSTNAME}, OU=ID, O=unknown, L=unknown, S=unknown, C=XX" \
+  -storepass "${KEYSTORE_PASSWORD}"
+
+  # Create signing request
+  keytool -keystore "${KEYSTORE_PATH}" -alias localhost -validity 1024 -certreq -keyalg RSA \
+   -storepass "${KEYSTORE_PASSWORD}" -noprompt > "${SIGNING_REQUEST}"
+
+  # Create CA
+  openssl req -x509 -keyout "${CA_KEY}" -newkey rsa:4096 -sha256 -nodes -out "${CA_CERT}" -outform PEM \
+  -subj "/C=XX/ST=unknown/L=unknown/O=unknown/CN=localhost"
+
+  # Signing server request
+  openssl x509 -req -CA "${CA_CERT}" -CAkey "${CA_KEY}" -CAcreateserial -in "${SIGNING_REQUEST}" \
+   -out "${SIGNED_CERT}"
+
+  # importing to server store
+  keytool -keystore "${KEYSTORE_PATH}" -alias CARoot -import -file "${CA_CERT}" -storepass "${KEYSTORE_PASSWORD}" -noprompt
+  keytool -keystore "${KEYSTORE_PATH}" -alias localhost -import -file "${SIGNED_CERT}" -storepass "${KEYSTORE_PASSWORD}" -noprompt
+fi

--- a/helpers/kafka-sasl-ssl/docker-compose.yml
+++ b/helpers/kafka-sasl-ssl/docker-compose.yml
@@ -1,0 +1,87 @@
+version: '2'
+
+services:
+
+  create-keys:
+    image: ${KAFKA_IMAGE}
+    user: "1000" # Update as needed
+    working_dir: "/etc/cert_path"
+    command: [
+      "sh", "-c",
+      "./create-certs.sh"
+    ]
+    volumes:
+      - "./:/etc/cert_path"
+  update-cdappconfig:
+    image: apteno/alpine-jq
+    working_dir: /root/cert_path
+    command: [
+      "sh", "-c",
+      "jq \".kafka.brokers[].cacert = \\\"`cat certs/ca/cacert.pem`\\\"\" cdappconfig-template.json > cdappconfig.json"
+    ]
+    volumes:
+      - "./:/root/cert_path"
+    depends_on:
+      create-keys:
+        condition: service_completed_successfully
+
+  zookeeper:
+    image: ${KAFKA_IMAGE}
+    command: [
+      "sh",
+      "-c",
+      "bin/zookeeper-server-start.sh config/zookeeper.properties"
+    ]
+    ports:
+      - "2181:2181"
+    environment:
+      LOG_DIR: /tmp/logs
+
+  zookeeper_post_init:
+    image: ${KAFKA_IMAGE}
+    command: [
+        "sh", "-c",
+        "bin/kafka-configs.sh --zookeeper zookeeper:2181 --alter --add-config 'SCRAM-SHA-512=[password='admin-secret']' --entity-type users --entity-name admin"
+    ]
+    depends_on:
+      zookeeper:
+        condition: service_started
+
+  kafka:
+    image: ${KAFKA_IMAGE}
+    command: [
+      "sh", "-c",
+      "bin/kafka-server-start.sh config/server.properties \
+        --override sasl.mechanism=SCRAM-SHA-512 \
+        --override sasl.enabled.mechanisms=SCRAM-SHA-512 \
+        --override security.protocol=SASL_SSL \
+        --override listeners=$${KAFKA_LISTENERS} \
+        --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} \
+        --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT} \
+        --override inter.broker.listener.name=$${KAFKA_SECURITY_INTER_BROKER_PROTOCOL} \
+        --override ssl.keystore.location=$${KAFKA_SSL_KEYSTORE_FILENAME} \
+        --override ssl.keystore.password=$${KAFKA_SSL_KEYSTORE_CREDENTIALS} \
+        --override ssl.endpoint.identification.algorithm='' \
+        --override enable.ssl.certificate.verification=false"
+    ]
+    depends_on:
+      zookeeper:
+        condition: service_started
+      create-keys:
+        condition: service_completed_successfully
+      zookeeper_post_init:
+        condition: service_completed_successfully
+    ports:
+      - "29092:29092"
+    environment:
+      LOG_DIR: "/tmp/logs"
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/kafka_server_jaas.conf"
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092,SASL_SSL://127.0.0.1:29092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,SASL_SSL://0.0.0.0:29092
+      KAFKA_SECURITY_INTER_BROKER_PROTOCOL: PLAINTEXT
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_SSL_KEYSTORE_FILENAME: /etc/certs-root/certs/server/server-keystore.jks
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: supersecure
+    volumes:
+      - "./:/etc/certs-root/"
+      - "./kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf"

--- a/helpers/kafka-sasl-ssl/kafka_server_jaas.conf
+++ b/helpers/kafka-sasl-ssl/kafka_server_jaas.conf
@@ -1,0 +1,6 @@
+KafkaServer {
+    org.apache.kafka.common.security.scram.ScramLoginModule required
+    username="admin"
+    password="admin-secret"
+    serviceName="localhost";
+};

--- a/helpers/kafka-ssl/.env
+++ b/helpers/kafka-ssl/.env
@@ -1,0 +1,1 @@
+KAFKA_IMAGE=strimzi/kafka:0.20.1-kafka-2.5.0

--- a/helpers/kafka-ssl/README.adoc
+++ b/helpers/kafka-ssl/README.adoc
@@ -21,11 +21,10 @@ docker-compose up
 .Start `policies-engine` passing the following environment variables:
 
 ```bash
-cd external;
 KAFKA_BOOTSTRAP_SERVERS="localhost:29092" \
 KAFKA_SECURITY_PROTOCOL="SSL" \
 KAFKA_SSL_TRUSTSTORE_LOCATION="`pwd`/../helpers/kafka-ssl/certs/ca/cacert.pem" \
 KAFKA_SSL_TRUSTSTORE_TYPE="PEM" \
 KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM="" \
-mvn compile quarkus:dev
+./mvnw compile quarkus:dev
 ```

--- a/helpers/kafka-ssl/create-certs.sh
+++ b/helpers/kafka-ssl/create-certs.sh
@@ -2,37 +2,43 @@
 
 set -e
 
-mkdir -p ./certs/server
-mkdir -p ./certs/ca
+if [[ -d "./certs" ]];
+then
+  echo "./certs exist - skipping creation"
+else
 
-KEYSTORE_PASSWORD="supersecure"
-KEYSTORE_PATH="./certs/server/server-keystore.jks"
-CA_CERT="./certs/ca/cacert.pem"
-CA_KEY="./certs/ca/cakey.pem"
-SIGNING_REQUEST="./certs/server/server.signing-request"
-SIGNED_CERT="./certs/server/server.certificate"
-KAFKA_HOSTNAME="localhost"
+  mkdir -p ./certs/server
+  mkdir -p ./certs/ca
 
-echo "Deleting previous cert/key (if found)"
-rm -f "${KEYSTORE_PATH}" "${SIGNING_REQUEST}" "${CA_CERT}" "${CA_KEY}" "${SIGNED_CERT}" "./certs/ca/cacert.srl"
+  KEYSTORE_PASSWORD="supersecure"
+  KEYSTORE_PATH="./certs/server/server-keystore.jks"
+  CA_CERT="./certs/ca/cacert.pem"
+  CA_KEY="./certs/ca/cakey.pem"
+  SIGNING_REQUEST="./certs/server/server.signing-request"
+  SIGNED_CERT="./certs/server/server.certificate"
+  KAFKA_HOSTNAME="localhost"
 
-# Create server key store
-keytool -keystore "${KEYSTORE_PATH}" -alias localhost -validity 1024 -genkey -keyalg RSA -storetype pkcs12 -noprompt \
--dname "CN=${KAFKA_HOSTNAME}, OU=ID, O=unknown, L=unknown, S=unknown, C=XX" \
--storepass "${KEYSTORE_PASSWORD}"
+  echo "Deleting previous cert/key (if found)"
+  rm -f "${KEYSTORE_PATH}" "${SIGNING_REQUEST}" "${CA_CERT}" "${CA_KEY}" "${SIGNED_CERT}" "./certs/ca/cacert.srl"
 
-# Create signing request
-keytool -keystore "${KEYSTORE_PATH}" -alias localhost -validity 1024 -certreq -keyalg RSA \
- -storepass "${KEYSTORE_PASSWORD}" -noprompt > "${SIGNING_REQUEST}"
+  # Create server key store
+  keytool -keystore "${KEYSTORE_PATH}" -alias localhost -validity 1024 -genkey -keyalg RSA -storetype pkcs12 -noprompt \
+  -dname "CN=${KAFKA_HOSTNAME}, OU=ID, O=unknown, L=unknown, S=unknown, C=XX" \
+  -storepass "${KEYSTORE_PASSWORD}"
 
-# Create CA
-openssl req -x509 -keyout "${CA_KEY}" -newkey rsa:4096 -sha256 -nodes -out "${CA_CERT}" -outform PEM \
--subj "/C=XX/ST=unknown/L=unknown/O=unknown/CN=localhost"
+  # Create signing request
+  keytool -keystore "${KEYSTORE_PATH}" -alias localhost -validity 1024 -certreq -keyalg RSA \
+   -storepass "${KEYSTORE_PASSWORD}" -noprompt > "${SIGNING_REQUEST}"
 
-# Signing server request
-openssl x509 -req -CA "${CA_CERT}" -CAkey "${CA_KEY}" -CAcreateserial -in "${SIGNING_REQUEST}" \
- -out "${SIGNED_CERT}"
+  # Create CA
+  openssl req -x509 -keyout "${CA_KEY}" -newkey rsa:4096 -sha256 -nodes -out "${CA_CERT}" -outform PEM \
+  -subj "/C=XX/ST=unknown/L=unknown/O=unknown/CN=localhost"
 
-# importing to server store
-keytool -keystore "${KEYSTORE_PATH}" -alias CARoot -import -file "${CA_CERT}" -storepass "${KEYSTORE_PASSWORD}" -noprompt
-keytool -keystore "${KEYSTORE_PATH}" -alias localhost -import -file "${SIGNED_CERT}" -storepass "${KEYSTORE_PASSWORD}" -noprompt
+  # Signing server request
+  openssl x509 -req -CA "${CA_CERT}" -CAkey "${CA_KEY}" -CAcreateserial -in "${SIGNING_REQUEST}" \
+   -out "${SIGNED_CERT}"
+
+  # importing to server store
+  keytool -keystore "${KEYSTORE_PATH}" -alias CARoot -import -file "${CA_CERT}" -storepass "${KEYSTORE_PASSWORD}" -noprompt
+  keytool -keystore "${KEYSTORE_PATH}" -alias localhost -import -file "${SIGNED_CERT}" -storepass "${KEYSTORE_PASSWORD}" -noprompt
+fi

--- a/helpers/kafka-ssl/docker-compose.yml
+++ b/helpers/kafka-ssl/docker-compose.yml
@@ -2,10 +2,22 @@ version: '2'
 
 services:
 
-  zookeeper:
-    image: strimzi/kafka:0.11.3-kafka-2.1.0
+  create-keys:
+    image: ${KAFKA_IMAGE}
+    user: "1000" # Update as needed
+    working_dir: "/etc/cert_path"
     command: [
       "sh", "-c",
+      "./create-certs.sh"
+    ]
+    volumes:
+      - "./:/etc/cert_path"
+
+  zookeeper:
+    image: ${KAFKA_IMAGE}
+    command: [
+      "sh",
+      "-c",
       "bin/zookeeper-server-start.sh config/zookeeper.properties"
     ]
     ports:
@@ -14,13 +26,24 @@ services:
       LOG_DIR: /tmp/logs
 
   kafka:
-    image: strimzi/kafka:0.11.3-kafka-2.1.0
+    image: ${KAFKA_IMAGE}
     command: [
       "sh", "-c",
-      "bin/kafka-server-start.sh config/server.properties --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT} --override inter.broker.listener.name=$${KAFKA_SECURITY_INTER_BROKER_PROTOCOL} --override ssl.keystore.location=$${KAFKA_SSL_KEYSTORE_FILENAME} --override ssl.keystore.password=$${KAFKA_SSL_KEYSTORE_CREDENTIALS} --override ssl.endpoint.identification.algorithm='' --override enable.ssl.certificate.verification=false"
+      "bin/kafka-server-start.sh config/server.properties \
+        --override listeners=$${KAFKA_LISTENERS} \
+        --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} \
+        --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT} \
+        --override inter.broker.listener.name=$${KAFKA_SECURITY_INTER_BROKER_PROTOCOL} \
+        --override ssl.keystore.location=$${KAFKA_SSL_KEYSTORE_FILENAME} \
+        --override ssl.keystore.password=$${KAFKA_SSL_KEYSTORE_CREDENTIALS} \
+        --override ssl.endpoint.identification.algorithm='' \
+        --override enable.ssl.certificate.verification=false"
     ]
     depends_on:
-      - zookeeper
+      zookeeper:
+        condition: service_started
+      create-keys:
+        condition: service_completed_successfully
     ports:
       - "29092:29092"
     environment:
@@ -29,7 +52,7 @@ services:
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,SSL://0.0.0.0:29092
       KAFKA_SECURITY_INTER_BROKER_PROTOCOL: PLAINTEXT
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_SSL_KEYSTORE_FILENAME: /etc/kafka/secrets/server-keystore.jks
+      KAFKA_SSL_KEYSTORE_FILENAME: /etc/certs-root/certs/server/server-keystore.jks
       KAFKA_SSL_KEYSTORE_CREDENTIALS: supersecure
     volumes:
-      - "./certs/server/server-keystore.jks:/etc/kafka/secrets/server-keystore.jks"
+      - "./:/etc/certs-root/"


### PR DESCRIPTION
 - Do not recrease
 - Include creationg in docker-compose startup

Some improvements to help testing kafka ssl

Easier to review with [hide whitespaces on](https://github.com/RedHatInsights/policies-engine/pull/497/files?diff=unified&w=1) 