### PR TITLE
RHCLOUD-24299 Protect against Kafka poison pills

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/engine/process/Receiver.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/process/Receiver.java
@@ -32,10 +32,14 @@ public class Receiver {
     @ActivateRequestContext
     public void process(String payload) {
         Log.tracef("Received payload: %s", payload);
-        payloadParser.parse(payload).ifPresent(event -> {
-            statelessSessionFactory.withSession(statelessSession -> {
-                eventProcessor.process(event);
+        try {
+            payloadParser.parse(payload).ifPresent(event -> {
+                statelessSessionFactory.withSession(statelessSession -> {
+                    eventProcessor.process(event);
+                });
             });
-        });
+        } catch (Exception e) {
+            Log.errorf(e, "Payload processing failed: %s", payload);
+        }
     }
 }

--- a/src/main/java/com/redhat/cloud/policies/engine/process/Receiver.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/process/Receiver.java
@@ -39,7 +39,15 @@ public class Receiver {
                 });
             });
         } catch (Exception e) {
-            Log.errorf(e, "Payload processing failed: %s", payload);
+            if (Log.isDebugEnabled()) {
+                /*
+                 * When the DEBUG log level is enabled, the log entry will include the payload.
+                 * The entry is still logged at ERROR level because the dev team needs to be alerted through Sentry that an issue happened.
+                 */
+                Log.errorf(e, "Payload processing failed: %s", payload);
+            } else {
+                Log.error("Payload processing failed. Set the log level to DEBUG to print the payload in the logs.", e);
+            }
         }
     }
 }


### PR DESCRIPTION
The Policies engine isn't protected enough against [Kafka poison pills](https://medium.com/lydtech-consulting/kafka-poison-pill-e146b87c1866). This PR adds the most basic yet very efficient way of preventing that kind of issue. You may want to use a different [error handling strategy](https://quarkus.io/guides/kafka#error-handling) in the future but in the meantime I recommend that this PR is merged as a first step.