### PR TITLE
feat: collect host groups for history entries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,12 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
     </dependency>
+    <!-- ORM types support incl. JSON (for Hibernate <= 5) -->
+    <dependency>
+      <groupId>io.quarkiverse.hibernatetypes</groupId>
+      <artifactId>quarkus-hibernate-types</artifactId>
+      <version>1.0.1</version>
+    </dependency>
 
     <!-- Insights -->
     <dependency>

--- a/src/main/java/com/redhat/cloud/policies/engine/db/entities/PoliciesHistoryEntry.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/db/entities/PoliciesHistoryEntry.java
@@ -1,14 +1,22 @@
 package com.redhat.cloud.policies.engine.db.entities;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import java.util.Objects;
 import java.util.UUID;
+import io.vertx.core.json.JsonArray;
+
+import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.Type;
+import io.quarkiverse.hibernate.types.json.JsonBinaryType;
+import io.quarkiverse.hibernate.types.json.JsonTypes;
 
 @Entity
 @Table(name = "policies_history")
+@TypeDef(name = JsonTypes.JSON_BIN, typeClass = JsonBinaryType.class)
 public class PoliciesHistoryEntry {
 
     @Id
@@ -26,6 +34,10 @@ public class PoliciesHistoryEntry {
     private String hostId;
 
     private String hostName;
+
+    @Type(type = JsonTypes.JSON_BIN)
+    @Column(name = "host_groups", nullable = false, columnDefinition = JsonTypes.JSON_BIN)
+    private JsonArray hostGroups = new JsonArray();
 
     public UUID getId() {
         return id;
@@ -81,6 +93,14 @@ public class PoliciesHistoryEntry {
 
     public void setHostName(String hostName) {
         this.hostName = hostName;
+    }
+
+    public JsonArray getHostGroups() {
+        return hostGroups;
+    }
+
+    public void setHostGroups(JsonArray hostGroups) {
+        this.hostGroups = hostGroups;
     }
 
     @Override

--- a/src/main/java/com/redhat/cloud/policies/engine/db/repositories/PoliciesHistoryRepository.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/db/repositories/PoliciesHistoryRepository.java
@@ -4,6 +4,7 @@ import com.redhat.cloud.policies.engine.db.StatelessSessionFactory;
 import com.redhat.cloud.policies.engine.db.entities.PoliciesHistoryEntry;
 import com.redhat.cloud.policies.engine.process.Event;
 import io.quarkus.logging.Log;
+import io.vertx.core.json.JsonArray;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -27,6 +28,7 @@ public class PoliciesHistoryRepository {
             historyEntry.setOrgId(event.getOrgId());
             historyEntry.setPolicyId(policyId.toString());
             historyEntry.setCtime(event.getCtime());
+            historyEntry.setHostGroups(getHostGroupsAsJsonArray(event));
             getSingleTagValue(event, INVENTORY_ID_FIELD).ifPresent(historyEntry::setHostId);
             getSingleTagValue(event, DISPLAY_NAME_FIELD).ifPresent(historyEntry::setHostName);
             statelessSessionFactory.getCurrentSession().insert(historyEntry);
@@ -43,5 +45,16 @@ public class PoliciesHistoryRepository {
         } else {
             return Optional.empty();
         }
+    }
+
+    private static JsonArray getHostGroupsAsJsonArray(Event event) {
+        var hostGroups = event.getHostGroups();
+        JsonArray json = new JsonArray();
+        if (hostGroups != null && hostGroups.size() > 0) {
+            hostGroups.forEach(group -> {
+                json.add(group.toJsonObject());
+            });
+        }
+        return json;
     }
 }

--- a/src/main/java/com/redhat/cloud/policies/engine/process/Event.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/process/Event.java
@@ -1,11 +1,18 @@
 package com.redhat.cloud.policies.engine.process;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 public class Event {
 
@@ -32,9 +39,38 @@ public class Event {
         }
     }
 
+    public static class HostGroup {
+        public final String id;
+        public final String name;
+
+        public HostGroup(String id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public HostGroup(JsonObject obj) {
+            this.id = obj.getString("id", "");
+            this.name = obj.getString("name", "");
+        }
+
+        public JsonObject toJsonObject() {
+            return new JsonObject(this.toMap());
+        }
+
+        public Map<String, Object> toMap() {
+            return Map.of("id", this.id, "name", this.name);
+        }
+
+        @Override
+        public String toString() {
+            return "HostGroup["+ name +";"+ id +"]";
+        }
+    }
+
     private String accountId;
     private String orgId;
     private String id;
+    private List<HostGroup> hostGroups = new LinkedList<HostGroup>();
     private long ctime;
     private String category;
     private String text;
@@ -67,6 +103,25 @@ public class Event {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public List<HostGroup> getHostGroups() {
+        return this.hostGroups;
+    }
+
+    public void setHostGroups(List<HostGroup> hostGroups) {
+        this.hostGroups = hostGroups;
+    }
+
+    public void addHostGroups(Iterable<Object> hostGroups) throws RuntimeException {
+        hostGroups.forEach(obj -> {
+            if (obj instanceof JsonObject) {
+                this.hostGroups.add(new HostGroup((JsonObject) obj));
+            } else {
+                throw new RuntimeException("Cannot handle host group of type "+ obj.getClass().toString()
+                                           + " to be addded to the collection");
+            }
+        });
     }
 
     public String getCategory() {

--- a/src/main/java/com/redhat/cloud/policies/engine/process/PayloadParser.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/process/PayloadParser.java
@@ -25,6 +25,7 @@ public class PayloadParser {
     public static final String CHECK_IN_FIELD = "check_in";
     public static final String HOST_FIELD = "host";
     public static final String HOST_ID = "id";
+    public static final String HOST_GROUPS_FIELD = "groups";
     public static final String CATEGORY_NAME = "insight_report";
     public static final String FQDN_NAME_FIELD = "fqdn";
     public static final String NETWORK_INTERFACES_FIELD = "network_interfaces";
@@ -122,6 +123,12 @@ public class PayloadParser {
         event.setTags(tagsMap);
         event.addTag(POLICIES_TAG_NAMESPACE, DISPLAY_NAME_FIELD, displayName, true);
         event.addTag(POLICIES_TAG_NAMESPACE, INVENTORY_ID_FIELD, json.getString(HOST_ID), true);
+
+        // Add Host Groups
+        JsonArray groups = json.getJsonArray(HOST_GROUPS_FIELD);
+        if (groups != null) {
+            event.addHostGroups(groups);
+        }
 
         // Additional context for processing
         Map<String, String> contextMap = new HashMap<>();

--- a/src/test/java/com/redhat/cloud/policies/engine/db/repositories/PoliciesHistoryRepositoryTest.java
+++ b/src/test/java/com/redhat/cloud/policies/engine/db/repositories/PoliciesHistoryRepositoryTest.java
@@ -1,0 +1,59 @@
+package com.redhat.cloud.policies.engine.db.repositories;
+
+import com.redhat.cloud.policies.engine.TestLifecycleManager;
+import com.redhat.cloud.policies.engine.db.StatelessSessionFactory;
+import com.redhat.cloud.policies.engine.db.entities.PoliciesHistoryEntry;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectSpy;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import org.hibernate.Session;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.cloud.policies.engine.process.Event;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+class PoliciesHistoryRepositoryTest {
+
+    @InjectSpy
+    StatelessSessionFactory statelessSessionFactory;
+
+    @Inject
+    Session session;
+
+    @Inject
+    PoliciesHistoryRepository repository;
+
+    @Test
+    public void testHostGroupsPersistence() {
+        var orgId = UUID.randomUUID().toString();
+        var event = new Event(UUID.randomUUID().toString(), orgId, "123", "category", "text");
+
+        List<Object> groups = List.of(JsonObject.of("name", "group_one",
+                                                    "id", "00000000-0000-0000-0000-000000000001"));
+        event.addHostGroups(groups);
+
+        statelessSessionFactory.withSession(session -> {
+            repository.create(UUID.randomUUID(), event);
+        });
+
+        var hql = "FROM PoliciesHistoryEntry WHERE orgId = :orgId";
+        var query = session.createQuery(hql, PoliciesHistoryEntry.class)
+                           .setParameter("orgId", orgId);
+        PoliciesHistoryEntry entry = query.getSingleResult();
+        assertNotNull("PoliciesHistoryEntry not found", entry);
+        assertEquals(orgId, entry.getOrgId());
+        assertEquals(new JsonArray(groups), entry.getHostGroups());
+    }
+}

--- a/src/test/java/com/redhat/cloud/policies/engine/process/EventTest.java
+++ b/src/test/java/com/redhat/cloud/policies/engine/process/EventTest.java
@@ -1,0 +1,41 @@
+package com.redhat.cloud.policies.engine.process;
+
+import com.redhat.cloud.policies.engine.process.Event.HostGroup;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+
+@QuarkusTest
+public class EventTest {
+    @Test
+    void testAddHostGroupsFromJsonObjects() {
+        Event event = new Event();
+
+        var group1 = new JsonObject(Map.of("name", "group_one", "id", "00000000-0000-0000-0000-000000000001"));
+        var group2 = new JsonObject(Map.of("name", "group_two", "id", "00000000-0000-0000-0000-000000000002"));
+        var groups = JsonArray.of(group1, group2);
+
+        event.addHostGroups(groups);
+        var addedGroups = event.getHostGroups();
+        assertEquals(2, addedGroups.size());
+        assertEquals("group_one", addedGroups.get(0).name);
+        assertEquals("00000000-0000-0000-0000-000000000001", addedGroups.get(0).id);
+        assertEquals("group_two", addedGroups.get(1).name);
+        assertEquals("00000000-0000-0000-0000-000000000002", addedGroups.get(1).id);
+    }
+
+    @Test
+    void testHostGroupToJsonObject() {
+        var group = new HostGroup("00000000-0000-0000-0000-000000000001", "group_one");
+        var expected = JsonObject.of("id", "00000000-0000-0000-0000-000000000001",
+                                     "name", "group_one");
+        assertEquals(expected, group.toJsonObject());
+    }
+}

--- a/src/test/java/com/redhat/cloud/policies/engine/process/PayloadParserTest.java
+++ b/src/test/java/com/redhat/cloud/policies/engine/process/PayloadParserTest.java
@@ -124,6 +124,10 @@ public class PayloadParserTest {
         assertNotNull(event.getFacts().get(NETWORK_INTERFACES_FIELD));
         assertNotNull(event.getFacts().get(YUM_REPOS_FIELD));
 
+        assertEquals(1, event.getHostGroups().size());
+        assertEquals("df57820e-965c-49a6-b0bc-797b7dd60581", event.getHostGroups().get(0).id);
+        assertEquals("Example group name", event.getHostGroups().get(0).name);
+
         CounterExpectations expectations = new CounterExpectations();
         expectations.incomingMessages = 1;
         checkCounterValues(expectations);

--- a/src/test/resources/db/migration/V25__RHINENG-1161_add_host_groups.sql
+++ b/src/test/resources/db/migration/V25__RHINENG-1161_add_host_groups.sql
@@ -1,0 +1,2 @@
+ALTER TABLE policies_history ADD column host_groups jsonb NOT NULL DEFAULT '[]'::jsonb;
+CREATE INDEX policies_history_host_groups_idx ON policies_history USING gin (host_groups jsonb_path_ops);

--- a/src/test/resources/input/host.json
+++ b/src/test/resources/input/host.json
@@ -9,6 +9,12 @@
     "reporter": "puptoo",
     "id": "ba11a21a-8b22-431b-9b4b-b06006472d54",
     "insights_id": "d4039530-4e3c-44d8-83b9-44de55400c2b",
+    "groups": [
+      {
+        "id": "df57820e-965c-49a6-b0bc-797b7dd60581",
+        "name": "Example group name"
+      }
+    ],
     "system_profile": {
       "arch": "string",
       "bios_release_date": "string",


### PR DESCRIPTION
Host groups are taken from inventory updates Kafka messages and stored on `PoliciesHistoryEntry` on a JSONB field `host_groups`.

`io.quarkiverse.hibernatetypes` is utilized to add support for JSONB fields, a they are being introduced from Hibernate version 6.2 (Quarkus 3 and up). However, our Quarkus version 2 uses Hibernate version 5.

Needs to be done together with https://github.com/RedHatInsights/policies-ui-backend/pull/559

RHINENG-1161