### PR TITLE
Update Security-Compliance Tag Naming Convention

### DIFF
--- a/.rhcicd/build_deploy.sh
+++ b/.rhcicd/build_deploy.sh
@@ -4,7 +4,7 @@ set -exv
 
 IMAGE="quay.io/cloudservices/policies-engine"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
-SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)"
+SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)-$(git rev-parse --short=7 HEAD)"
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     echo "QUAY_USER and QUAY_TOKEN must be set"


### PR DESCRIPTION
## Overview
This PR updates the `Security-Compliance Tag` Naming Convention within the `build_deploy.sh` to make it easier to identify the Git Commit the image is based on.

Example:
- OLD: `sc-20230920`
- NEW: `sc-20230920-f963f6f`