### PR TITLE
chore: update quarkus 2.16.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <!-- Quarkus -->
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.13.4.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.16.12.Final</quarkus.platform.version>
 
     <!-- Dependencies -->
     <insights-notification-schemas-java.version>0.17</insights-notification-schemas-java.version>

--- a/src/test/java/com/redhat/cloud/policies/engine/NonApplicationRootPathTest.java
+++ b/src/test/java/com/redhat/cloud/policies/engine/NonApplicationRootPathTest.java
@@ -30,6 +30,7 @@ public class NonApplicationRootPathTest {
     @Test
     void testMetrics() {
         given()
+                .header("Accept", "text/plain")
                 .when().get("/metrics")
                 .then()
                 .statusCode(200)


### PR DESCRIPTION
Upgrades to newest Quarkus 2: 2.16.12.

Refactors tests to support this upgrade.

[RHINENG-2697](https://issues.redhat.com/browse/RHINENG-2697)