### PR TITLE
chore(upgrade): Quarkus 3.2

### DIFF
--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -8,6 +8,10 @@ export COMPONENT_NAME="policies-engine"
 export IMAGE="quay.io/cloudservices/policies-engine"
 export DEPLOY_TIMEOUT="600"
 
+# Temporary deploy template fix of policies-ui-backend [RHINENG-6805]
+EXTRA_DEPLOY_ARGS="--set-template-ref policies-ui-backend=ddeef618125b31f083788040b6344cca372ec09c
+                   --set-image-tag quay.io/cloudservices/policies-ui-backend=pr-602-ddeef61"
+
 # IQE plugin config
 export IQE_PLUGINS="policies"
 export IQE_MARKER_EXPRESSION="policies_api_smoke"

--- a/pom.xml
+++ b/pom.xml
@@ -44,16 +44,16 @@
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
 
     <!-- Quarkus -->
+    <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.16.12.Final</quarkus.platform.version>
+    <quarkus.platform.version>3.2.9.Final-redhat-00003</quarkus.platform.version>
 
     <!-- Dependencies -->
     <insights-notification-schemas-java.version>0.17</insights-notification-schemas-java.version>
     <redhat.event-schemas.version>1.4.2</redhat.event-schemas.version>
     <clowder-quarkus-config-source.version>1.2.0</clowder-quarkus-config-source.version>
-    <quarkus-logging-cloudwatch.version>5.6.0</quarkus-logging-cloudwatch.version>
-    <quarkus-logging-sentry.version>1.2.1</quarkus-logging-sentry.version>
+    <quarkus-logging-cloudwatch.version>6.3.0</quarkus-logging-cloudwatch.version>
+    <quarkus-logging-sentry.version>2.0.4</quarkus-logging-sentry.version>
     <org.antlr.version>4.11.1</org.antlr.version>
 
   </properties>
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>io.quarkiverse.hibernatetypes</groupId>
       <artifactId>quarkus-hibernate-types</artifactId>
-      <version>1.0.1</version>
+      <version>2.0.0</version>
     </dependency>
 
     <!-- Insights -->
@@ -197,84 +197,35 @@
 
   </dependencies>
 
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>redhat</id>
+      <url>https://maven.repository.redhat.com/ga</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>redhat</id>
+      <url>https://maven.repository.redhat.com/ga</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <version>${enforcer-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>enforce-versions</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireMavenVersion>
-                  <version>${maven-minimum-version}</version>
-                </requireMavenVersion>
-                <requireJavaVersion>
-                  <version>${java-version}</version>
-                </requireJavaVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler-plugin.version}</version>
-        <configuration>
-          <release>17</release>
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
-        <configuration>
-          <trimStackTrace>false</trimStackTrace>
-          <systemProperties>
-            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-          </systemProperties>
-        </configuration>
-      </plugin>
-
-      <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-clean-plugin</artifactId>
-          <version>3.2.0</version>
-      </plugin>
-      <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.1.1</version>
-      </plugin>
-      <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.1</version>
-      </plugin>
-      <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>${maven-jar-plugin.version}</version>
-      </plugin>
-      <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-resources-plugin</artifactId>
-          <version>3.3.1</version>
-      </plugin>
-      <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>4.0.0-M5</version>
-      </plugin>
-
-      <plugin>
-        <groupId>io.quarkus</groupId>
+        <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>
         <extensions>true</extensions>
@@ -287,10 +238,44 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${compiler-plugin.version}</version>
         <configuration>
-          <debug>5006</debug>
-          <suspend>false</suspend>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
         </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire-plugin.version}</version>
+        <configuration>
+          <systemPropertyVariables>
+            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+            <maven.home>${maven.home}</maven.home>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${surefire-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                <maven.home>${maven.home}</maven.home>
+              </systemPropertyVariables>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>io.github.git-commit-id</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
 
     <maven.compiler.parameters>true</maven.compiler.parameters>
+    <maven.compiler.release>${java-version}</maven.compiler.release>
     <maven.compiler.source>$java-version}</maven.compiler.source>
     <maven.compiler.target>$java-version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/redhat/cloud/policies/engine/RunOnStartup.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/RunOnStartup.java
@@ -2,13 +2,13 @@ package com.redhat.cloud.policies.engine;
 
 import io.quarkus.logging.Log;
 import io.quarkus.runtime.Startup;
+import jakarta.annotation.PostConstruct;
+
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.regex.Pattern;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-
-import javax.annotation.PostConstruct;
 
 @Startup
 public class RunOnStartup {

--- a/src/main/java/com/redhat/cloud/policies/engine/clowder/KafkaSaslInitializer.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/clowder/KafkaSaslInitializer.java
@@ -2,14 +2,14 @@ package com.redhat.cloud.policies.engine.clowder;
 
 import io.quarkus.logging.Log;
 import io.quarkus.runtime.StartupEvent;
+import jakarta.annotation.Priority;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
-import javax.annotation.Priority;
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 
-import static javax.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
+import static jakarta.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
 
 /*
  * This bean is required to make sure that SmallRye Reactive Messaging will use the configuration from

--- a/src/main/java/com/redhat/cloud/policies/engine/config/FeatureFlipper.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/config/FeatureFlipper.java
@@ -5,8 +5,8 @@ import io.quarkus.runtime.StartupEvent;
 import io.quarkus.runtime.configuration.ProfileManager;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 
 import static io.quarkus.runtime.LaunchMode.TEST;
 

--- a/src/main/java/com/redhat/cloud/policies/engine/db/StatelessSessionFactory.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/db/StatelessSessionFactory.java
@@ -4,9 +4,9 @@ import io.quarkus.logging.Log;
 import org.hibernate.Session;
 import org.hibernate.StatelessSession;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.persistence.EntityManager;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
 import java.util.function.Consumer;
 import java.util.function.Function;
 

--- a/src/main/java/com/redhat/cloud/policies/engine/db/entities/OrgIdLatestUpdate.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/db/entities/OrgIdLatestUpdate.java
@@ -1,9 +1,9 @@
 package com.redhat.cloud.policies.engine.db.entities;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 
 @Entity

--- a/src/main/java/com/redhat/cloud/policies/engine/db/entities/PoliciesHistoryEntry.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/db/entities/PoliciesHistoryEntry.java
@@ -3,24 +3,23 @@ package com.redhat.cloud.policies.engine.db.entities;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.Objects;
 import java.util.UUID;
 import io.vertx.core.json.JsonArray;
 
-import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.Type;
 import io.quarkiverse.hibernate.types.json.JsonBinaryType;
 import io.quarkiverse.hibernate.types.json.JsonTypes;
 
 @Entity
 @Table(name = "policies_history")
-@TypeDef(name = JsonTypes.JSON_BIN, typeClass = JsonBinaryType.class)
 public class PoliciesHistoryEntry {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     private String tenantId;
@@ -35,7 +34,7 @@ public class PoliciesHistoryEntry {
 
     private String hostName;
 
-    @Type(type = JsonTypes.JSON_BIN)
+    @Type(JsonBinaryType.class)
     @Column(name = "host_groups", nullable = false, columnDefinition = JsonTypes.JSON_BIN)
     private JsonArray hostGroups = new JsonArray();
 

--- a/src/main/java/com/redhat/cloud/policies/engine/db/entities/PoliciesHistoryEntry.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/db/entities/PoliciesHistoryEntry.java
@@ -1,10 +1,10 @@
 package com.redhat.cloud.policies.engine.db.entities;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.util.Objects;
 import java.util.UUID;
 import io.vertx.core.json.JsonArray;

--- a/src/main/java/com/redhat/cloud/policies/engine/db/entities/Policy.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/db/entities/Policy.java
@@ -1,9 +1,9 @@
 package com.redhat.cloud.policies.engine.db.entities;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.util.UUID;
 
 @Entity

--- a/src/main/java/com/redhat/cloud/policies/engine/db/repositories/PoliciesHistoryRepository.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/db/repositories/PoliciesHistoryRepository.java
@@ -6,8 +6,8 @@ import com.redhat.cloud.policies.engine.process.Event;
 import io.quarkus.logging.Log;
 import io.vertx.core.json.JsonArray;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.UUID;

--- a/src/main/java/com/redhat/cloud/policies/engine/db/repositories/PoliciesRepository.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/db/repositories/PoliciesRepository.java
@@ -6,9 +6,9 @@ import io.quarkus.cache.CacheInvalidateAll;
 import io.quarkus.cache.CacheResult;
 import io.quarkus.logging.Log;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.persistence.NoResultException;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.NoResultException;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/com/redhat/cloud/policies/engine/db/repositories/PoliciesRepository.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/db/repositories/PoliciesRepository.java
@@ -55,7 +55,7 @@ public class PoliciesRepository {
     }
 
     private List<Policy> findEnabledPolicies(String orgId) {
-        String hql = "FROM Policy WHERE orgId = :orgId AND enabled IS TRUE";
+        String hql = "FROM Policy WHERE orgId = :orgId AND enabled = TRUE";
         return statelessSessionFactory.getCurrentSession().createQuery(hql, Policy.class)
                 .setParameter("orgId", orgId)
                 .getResultList();

--- a/src/main/java/com/redhat/cloud/policies/engine/metrics/ProcSelfStatusExporter.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/metrics/ProcSelfStatusExporter.java
@@ -4,10 +4,10 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.quarkus.logging.Log;
 import io.quarkus.scheduler.Scheduled;
+import jakarta.annotation.PostConstruct;
 
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.io.File;
 import java.util.Scanner;
 import java.util.Set;

--- a/src/main/java/com/redhat/cloud/policies/engine/process/EventProcessor.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/process/EventProcessor.java
@@ -8,11 +8,11 @@ import com.redhat.cloud.policies.engine.db.repositories.PoliciesHistoryRepositor
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.logging.Log;
+import jakarta.annotation.PostConstruct;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;

--- a/src/main/java/com/redhat/cloud/policies/engine/process/NotificationSender.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/process/NotificationSender.java
@@ -12,15 +12,15 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.logging.Log;
 import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
 import io.vertx.core.json.JsonObject;
+import jakarta.annotation.PostConstruct;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.OnOverflow;
 
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;

--- a/src/main/java/com/redhat/cloud/policies/engine/process/PayloadParser.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/process/PayloadParser.java
@@ -5,10 +5,10 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.logging.Log;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import jakarta.annotation.PostConstruct;
 
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;

--- a/src/main/java/com/redhat/cloud/policies/engine/process/Receiver.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/process/Receiver.java
@@ -5,9 +5,9 @@ import io.quarkus.logging.Log;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.context.control.ActivateRequestContext;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
 
 /**
  * This is the main process for Policies. It ingests data from Kafka, enriches it with information from

--- a/src/main/java/com/redhat/cloud/policies/engine/rest/LightweightEngineResource.java
+++ b/src/main/java/com/redhat/cloud/policies/engine/rest/LightweightEngineResource.java
@@ -4,16 +4,16 @@ import com.redhat.cloud.policies.engine.condition.ConditionParser;
 import io.quarkus.logging.Log;
 import io.vertx.core.json.JsonObject;
 
-import javax.validation.constraints.NotNull;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 
 import java.util.Map;
 
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 
 @Path("/lightweight-engine")
 public class LightweightEngineResource {

--- a/src/test/java/com/redhat/cloud/policies/engine/TestLifecycleManager.java
+++ b/src/test/java/com/redhat/cloud/policies/engine/TestLifecycleManager.java
@@ -1,7 +1,7 @@
 package com.redhat.cloud.policies.engine;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import io.smallrye.reactive.messaging.providers.connectors.InMemoryConnector;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import java.util.HashMap;
@@ -9,8 +9,8 @@ import java.util.Map;
 
 import static com.redhat.cloud.policies.engine.process.NotificationSender.WEBHOOK_CHANNEL;
 import static com.redhat.cloud.policies.engine.process.Receiver.EVENTS_CHANNEL;
-import static io.smallrye.reactive.messaging.providers.connectors.InMemoryConnector.switchIncomingChannelsToInMemory;
-import static io.smallrye.reactive.messaging.providers.connectors.InMemoryConnector.switchOutgoingChannelsToInMemory;
+import static io.smallrye.reactive.messaging.memory.InMemoryConnector.switchIncomingChannelsToInMemory;
+import static io.smallrye.reactive.messaging.memory.InMemoryConnector.switchOutgoingChannelsToInMemory;
 
 public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager {
 

--- a/src/test/java/com/redhat/cloud/policies/engine/db/StatelessSessionFactoryTest.java
+++ b/src/test/java/com/redhat/cloud/policies/engine/db/StatelessSessionFactoryTest.java
@@ -5,7 +5,7 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/src/test/java/com/redhat/cloud/policies/engine/db/repositories/PoliciesHistoryRepositoryTest.java
+++ b/src/test/java/com/redhat/cloud/policies/engine/db/repositories/PoliciesHistoryRepositoryTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import com.redhat.cloud.policies.engine.process.Event;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.util.List;
 import java.util.UUID;
 

--- a/src/test/java/com/redhat/cloud/policies/engine/db/repositories/PoliciesRepositoryTest.java
+++ b/src/test/java/com/redhat/cloud/policies/engine/db/repositories/PoliciesRepositoryTest.java
@@ -1,0 +1,65 @@
+package com.redhat.cloud.policies.engine.db.repositories;
+
+import com.redhat.cloud.policies.engine.TestLifecycleManager;
+import com.redhat.cloud.policies.engine.db.StatelessSessionFactory;
+import com.redhat.cloud.policies.engine.db.entities.Policy;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectSpy;
+
+import org.hibernate.Session;
+import org.junit.jupiter.api.Test;
+
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+class PoliciesRepositoryTest {
+
+    @InjectSpy
+    StatelessSessionFactory statelessSessionFactory;
+
+    @Inject
+    Session session;
+
+    @Inject
+    PoliciesRepository repository;
+
+    @Test
+    public void testGetEnabledPolicies() {
+        String orgId = UUID.randomUUID().toString();
+
+        Policy policyFixture = createEnabledPolicy(orgId);
+
+        statelessSessionFactory.withSession(session -> {
+            List<Policy> enabledPolicies = repository.getEnabledPolicies(orgId);
+            assertEquals(1, enabledPolicies.size());
+            assertEquals(orgId, enabledPolicies.get(0).orgId);
+            assertEquals(policyFixture.id, enabledPolicies.get(0).id);
+        });
+    }
+
+    @Transactional
+    Policy createEnabledPolicy(String orgId) {
+        Policy policy = new Policy();
+        policy.id = UUID.randomUUID();
+        policy.accountId = "123";
+        policy.orgId = orgId;
+        policy.name = "Test";
+        policy.description = "desc";
+        policy.condition = "true";
+        policy.enabled = true;
+        policy.actions = "none";
+        session.persist(policy);
+
+        return policy;
+    }
+}

--- a/src/test/java/com/redhat/cloud/policies/engine/process/EventProcessorTest.java
+++ b/src/test/java/com/redhat/cloud/policies/engine/process/EventProcessorTest.java
@@ -6,13 +6,13 @@ import com.redhat.cloud.policies.engine.config.FeatureFlipper;
 import com.redhat.cloud.policies.engine.db.entities.Policy;
 import com.redhat.cloud.policies.engine.db.repositories.PoliciesHistoryRepository;
 import com.redhat.cloud.policies.engine.db.repositories.PoliciesRepository;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;

--- a/src/test/java/com/redhat/cloud/policies/engine/process/NotificationSenderTest.java
+++ b/src/test/java/com/redhat/cloud/policies/engine/process/NotificationSenderTest.java
@@ -16,16 +16,16 @@ import com.redhat.cloud.policies.engine.config.FeatureFlipper;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.smallrye.reactive.messaging.kafka.api.KafkaMessageMetadata;
-import io.smallrye.reactive.messaging.providers.connectors.InMemoryConnector;
-import io.smallrye.reactive.messaging.providers.connectors.InMemorySink;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import io.smallrye.reactive.messaging.memory.InMemorySink;
+import jakarta.annotation.PostConstruct;
 import org.apache.kafka.common.header.Header;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.PostConstruct;
-import javax.enterprise.inject.Any;
-import javax.inject.Inject;
+import jakarta.enterprise.inject.Any;
+import jakarta.inject.Inject;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;

--- a/src/test/java/com/redhat/cloud/policies/engine/process/PayloadParserTest.java
+++ b/src/test/java/com/redhat/cloud/policies/engine/process/PayloadParserTest.java
@@ -4,13 +4,13 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.test.junit.QuarkusTest;
 import io.vertx.core.json.JsonObject;
+import jakarta.annotation.PostConstruct;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;

--- a/src/test/java/com/redhat/cloud/policies/engine/process/ReceiverTest.java
+++ b/src/test/java/com/redhat/cloud/policies/engine/process/ReceiverTest.java
@@ -2,15 +2,15 @@ package com.redhat.cloud.policies.engine.process;
 
 import com.redhat.cloud.policies.engine.TestLifecycleManager;
 import com.redhat.cloud.policies.engine.db.StatelessSessionFactory;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
 import io.quarkus.test.junit.mockito.InjectSpy;
-import io.smallrye.reactive.messaging.providers.connectors.InMemoryConnector;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
 import org.junit.jupiter.api.Test;
 
-import javax.enterprise.inject.Any;
-import javax.inject.Inject;
+import jakarta.enterprise.inject.Any;
+import jakarta.inject.Inject;
 
 import java.util.Optional;
 import java.util.function.Consumer;


### PR DESCRIPTION
Upgrades to Red Hat build of Quarkus 3.2.

Due to the migration, these fixes had to be applied:
* migration to Hibernate 6 type system, while keeping quarkus-hibernate-types
 
RHINENG-1631
RHINENG-774