### PR TITLE
ci: update temporary backend-ui ref

### DIFF
--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -9,8 +9,8 @@ export IMAGE="quay.io/cloudservices/policies-engine"
 export DEPLOY_TIMEOUT="600"
 
 # Temporary deploy template fix of policies-ui-backend [RHINENG-6805]
-EXTRA_DEPLOY_ARGS="--set-template-ref policies-ui-backend=ddeef618125b31f083788040b6344cca372ec09c
-                   --set-image-tag quay.io/cloudservices/policies-ui-backend=pr-602-ddeef61"
+EXTRA_DEPLOY_ARGS="--set-template-ref policies-ui-backend=6a9c59d80231a36ba6e87af5e8be28158bbe2d64
+                   --set-image-tag quay.io/cloudservices/policies-ui-backend=6a9c59d"
 
 # IQE plugin config
 export IQE_PLUGINS="policies"


### PR DESCRIPTION
Updates the temporary policies-ui-backend reference within PR check, as the previous image was already removed (was from a PR).