### PR TITLE
Convert container image/Dockerfile from UBI8 to UBI9

### DIFF
--- a/src/main/docker/Dockerfile-build.jvm
+++ b/src/main/docker/Dockerfile-build.jvm
@@ -3,21 +3,21 @@
 ###
 
 # Build the project
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
 RUN ./mvnw clean package -DskipTests --no-transfer-progress
 
 # Build the container
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ARG JAVA_PACKAGE=java-17-openjdk-headless
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 
 # Install java
 # Also set up permissions for user `1001`
-RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+RUN microdnf install -y openssl ca-certificates ${JAVA_PACKAGE} \
     && microdnf update \
     && microdnf clean all \
     && mkdir /deployments \


### PR DESCRIPTION
This PR should replace of using UBI8 images with UBI9.
I was able to build new image with:

```
podman build . -f ./src/main/docker/Dockerfile.jvm -t test_build_policies_ui_backend --ulimit=nofile=4096
```

I confirmed that curl exists in the final image as I had to remove it from dockerfile due to installation conflict.