### PR TITLE
fix(CI): use jq in checkimage

### DIFF
--- a/.github/workflows/checkupdate.yml
+++ b/.github/workflows/checkupdate.yml
@@ -20,8 +20,7 @@ jobs:
         run: sudo apt-get install -y skopeo
       - name: check change
         run: |
-          skopeo inspect docker://registry.access.redhat.com/ubi8/ubi-minimal:latest | grep -Po '(?<="Digest": ")([^"]+)' \
-            | head -n1 > .baseimage
+          skopeo inspect docker://registry.access.redhat.com/ubi8/ubi-minimal:latest | jq .Digest --raw-output > .baseimage
           docker run --rm --entrypoint sh -u 0 quay.io/cloudservices/policies-engine:latest -c \
             'microdnf update > /dev/null; rpm -qa | sort | sha256sum' \
             >> .baseimage


### PR DESCRIPTION
Use jq to query for image digest to remove the need to rely on skopeo inspect output having json keys in particular order. RHINENG-13679