### PR TITLE
ci: fix image check update

### DIFF
--- a/.github/workflows/checkupdate.yml
+++ b/.github/workflows/checkupdate.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           skopeo inspect docker://registry.access.redhat.com/ubi9/ubi-minimal:latest | jq .Digest --raw-output > .baseimage
           docker run --rm --entrypoint sh -u 0 quay.io/cloudservices/policies-engine:latest -c \
-            'microdnf update > /dev/null; rpm -qa | sort | sha256sum' \
+            'microdnf update -y > /dev/null; rpm -qa | sort | sha256sum' \
             >> .baseimage
       - name: do change if the digest changed
         run: |


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add -y flag to microdnf update in image check workflow to enable non-interactive updates