### PR TITLE
chore(deps): bump insights-notification-schemas-java and event-schemas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
     <quarkus.platform.version>3.20.1.redhat-00003</quarkus.platform.version>
 
     <!-- Dependencies -->
-    <insights-notification-schemas-java.version>0.22</insights-notification-schemas-java.version>
-    <redhat.event-schemas.version>1.4.11</redhat.event-schemas.version>
+    <insights-notification-schemas-java.version>0.23</insights-notification-schemas-java.version>
+    <redhat.event-schemas.version>1.4.12</redhat.event-schemas.version>
     <clowder-quarkus-config-source.version>2.7.1</clowder-quarkus-config-source.version>
     <quarkus-logging-cloudwatch.version>6.13.0</quarkus-logging-cloudwatch.version>
     <quarkus-logging-sentry.version>2.1.5</quarkus-logging-sentry.version>


### PR DESCRIPTION
- Bumps com.redhat.cloud.event:event-schemas from 1.4.11 to 1.4.12.
- Bumps com.redhat.cloud.common:insights-notification-schemas-java from 0.22 to 0.23.

## Summary by Sourcery

Bump insights-notification-schemas-java and event-schemas dependencies to their latest patch versions

Build:
- Update insights-notification-schemas-java from 0.22 to 0.23
- Update event-schemas from 1.4.11 to 1.4.12