### PR TITLE
Test sentry shared konflux pipeline

### DIFF
--- a/.tekton/policies-engine-pull-request.yaml
+++ b/.tekton/policies-engine-pull-request.yaml
@@ -9,7 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.34.0/pipelines/docker-build-oci-ta.yaml
+    # pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.34.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/adonispuente/konflux-pipelines/raw/silly/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-policies

--- a/.tekton/policies-engine-push.yaml
+++ b/.tekton/policies-engine-push.yaml
@@ -8,7 +8,8 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.34.0/pipelines/docker-build-oci-ta.yaml
+    # pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.34.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/adonispuente/konflux-pipelines/raw/silly/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-policies


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update pipelinesascode.tekton.dev/pipeline URL in pull-request and push configs to adonispuente/konflux-pipelines silly branch, commenting out the original official pipeline link